### PR TITLE
Add libraries from notebook to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,10 @@ Django>=4.2
 gunicorn
 psycopg2-binary
 django-environ
+pandas
+numpy
+yfinance
+mplfinance
+scikit-learn
+xgboost
+hmmlearn


### PR DESCRIPTION
## Summary
- include pandas, numpy, yfinance and more in requirements

## Testing
- `pip install -r requirements.txt`
- `python manage.py check` *(fails: SECRET_KEY not set)*

------
https://chatgpt.com/codex/tasks/task_e_684545d6d6ec8329a5083f0e96b4f81a