### PR TITLE
Update README for JQUANTS_TOKEN setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ This is a simple Django project containing a single application `core`.
    railway add         # add Postgres plugin
    ```
 3. In the Railway dashboard, add the environment variables `SECRET_KEY`, `DATABASE_URL`, and `DEBUG`.
+4. Sign up for a free account at [J-Quants](https://jpx-jquants.com/) to obtain your API token. Add this token to the Railway dashboard as `JQUANTS_TOKEN`.
 
 ## Development
 
@@ -30,6 +31,15 @@ Example Git workflow:
 git init
 git add .
 git commit -m "Initial commit"
+```
+
+For local development, create a `.env` file and define your environment variables:
+
+```bash
+SECRET_KEY=your-secret-key
+DATABASE_URL=your-database-url
+DEBUG=True
+JQUANTS_TOKEN=your-token
 ```
 
 Install dependencies and run the server:


### PR DESCRIPTION
## Summary
- document where to obtain `JQUANTS_TOKEN`
- show how to configure `JQUANTS_TOKEN` on Railway and locally

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6845474877088329aac73825ba7d2411