### PR TITLE
Add stock analysis module and view

### DIFF
--- a/core/analysis.py
+++ b/core/analysis.py
@@ -1,0 +1,40 @@
+import pandas as pd
+import yfinance as yf
+import matplotlib.pyplot as plt
+from io import BytesIO
+import base64
+
+
+def analyze_stock(ticker: str):
+    """Fetch data and return base64 chart image and HTML table."""
+    ticker_symbol = f"{ticker}.T" if not ticker.endswith('.T') else ticker
+    df = yf.download(ticker_symbol, period="1y", interval="1d")
+    if df.empty:
+        return None, None
+
+    df["MA5"] = df["Close"].rolling(window=5).mean()
+    df["MA25"] = df["Close"].rolling(window=25).mean()
+
+    plt.figure(figsize=(10, 5))
+    plt.plot(df.index, df["Close"], label="Close")
+    plt.plot(df.index, df["MA5"], label="MA5")
+    plt.plot(df.index, df["MA25"], label="MA25")
+    plt.legend()
+    plt.xlabel("Date")
+    plt.ylabel("Price")
+    plt.title(f"{ticker_symbol} Close Price")
+    plt.tight_layout()
+
+    buf = BytesIO()
+    plt.savefig(buf, format="png")
+    plt.close()
+    buf.seek(0)
+    chart_data = base64.b64encode(buf.getvalue()).decode("utf-8")
+
+    table_html = (
+        df.tail(5)[["Close", "MA5", "MA25"]]
+        .round(2)
+        .to_html(classes="table table-striped")
+    )
+
+    return chart_data, table_html

--- a/core/templates/base.html
+++ b/core/templates/base.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>MyApp</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
+</head>
+<body>
+<div class="container mt-4">
+{% block content %}{% endblock %}
+</div>
+</body>
+</html>

--- a/core/templates/core/stock_analysis.html
+++ b/core/templates/core/stock_analysis.html
@@ -1,0 +1,17 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Stock Analysis</h1>
+<form method="post">
+  {% csrf_token %}
+  <input type="text" name="ticker" value="{{ ticker }}" placeholder="Ticker code">
+  <button type="submit">Analyze</button>
+</form>
+{% if chart_data %}
+  <h2>Chart</h2>
+  <img src="data:image/png;base64,{{ chart_data }}" alt="Chart">
+{% endif %}
+{% if table_html %}
+  <h2>Latest Data</h2>
+  {{ table_html|safe }}
+{% endif %}
+{% endblock %}

--- a/core/urls.py
+++ b/core/urls.py
@@ -1,0 +1,6 @@
+from django.urls import path
+from .views import stock_analysis_view
+
+urlpatterns = [
+    path('', stock_analysis_view, name='stock_analysis'),
+]

--- a/core/views.py
+++ b/core/views.py
@@ -1,3 +1,20 @@
 from django.shortcuts import render
+from .analysis import analyze_stock
 
-# Create your views here.
+
+def stock_analysis_view(request):
+    chart_data = None
+    table_html = None
+    ticker = ""
+
+    if request.method == "POST":
+        ticker = request.POST.get("ticker", "").strip()
+        if ticker:
+            chart_data, table_html = analyze_stock(ticker)
+
+    context = {
+        "ticker": ticker,
+        "chart_data": chart_data,
+        "table_html": table_html,
+    }
+    return render(request, "core/stock_analysis.html", context)

--- a/myapp/urls.py
+++ b/myapp/urls.py
@@ -16,8 +16,9 @@ Including another URLconf
 """
 
 from django.contrib import admin
-from django.urls import path
+from django.urls import path, include
 
 urlpatterns = [
     path("admin/", admin.site.urls),
+    path("", include("core.urls")),
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ pandas
 numpy
 yfinance
 mplfinance
+matplotlib
 scikit-learn
 xgboost
 hmmlearn


### PR DESCRIPTION
## Summary
- create `core/analysis.py` with a simple moving-average analysis
- render analysis results with new view and template
- add URL configuration for the new view
- include minimal base template
- update requirements with matplotlib

## Testing
- `pip install -r requirements.txt`
- `python manage.py check` *(fails: SECRET_KEY not set)*


------
https://chatgpt.com/codex/tasks/task_e_6845489acee48329aa77deb93a8f421a