### PR TITLE
Add candlestick view

### DIFF
--- a/core/analysis.py
+++ b/core/analysis.py
@@ -3,6 +3,7 @@ import yfinance as yf
 import matplotlib.pyplot as plt
 from io import BytesIO
 import base64
+import mplfinance as mpf
 
 
 def analyze_stock(ticker: str):
@@ -33,6 +34,45 @@ def analyze_stock(ticker: str):
 
     table_html = (
         df.tail(5)[["Close", "MA5", "MA25"]]
+        .round(2)
+        .to_html(classes="table table-striped")
+    )
+
+    return chart_data, table_html
+
+
+def analyze_stock_candlestick(ticker: str):
+    """Generate candlestick chart with volume and MA lines."""
+    ticker_symbol = f"{ticker}.T" if not ticker.endswith('.T') else ticker
+    df = yf.download(ticker_symbol, period="6mo", interval="1d")
+    if df.empty:
+        return None, None
+
+    df["MA5"] = df["Close"].rolling(window=5).mean()
+    df["MA25"] = df["Close"].rolling(window=25).mean()
+    df["MA75"] = df["Close"].rolling(window=75).mean()
+
+    plot_df = df[["Open", "High", "Low", "Close", "Volume"]].dropna().astype(float)
+
+    fig, ax = mpf.plot(
+        plot_df,
+        type="candle",
+        mav=(5, 25, 75),
+        volume=True,
+        title=f"{ticker_symbol} Daily Candlestick and Volume (MA:5,25,75)",
+        style="yahoo",
+        returnfig=True,
+        figsize=(12, 8),
+    )
+
+    buf = BytesIO()
+    fig.savefig(buf, format="png")
+    plt.close(fig)
+    buf.seek(0)
+    chart_data = base64.b64encode(buf.getvalue()).decode("utf-8")
+
+    table_html = (
+        df.tail(5)[["Close", "MA5", "MA25", "MA75"]]
         .round(2)
         .to_html(classes="table table-striped")
     )

--- a/core/templates/core/candlestick_analysis.html
+++ b/core/templates/core/candlestick_analysis.html
@@ -1,0 +1,17 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Candlestick Analysis</h1>
+<form method="post">
+  {% csrf_token %}
+  <input type="text" name="ticker" value="{{ ticker }}" placeholder="Ticker code">
+  <button type="submit">Analyze</button>
+</form>
+{% if chart_data %}
+  <h2>Chart</h2>
+  <img src="data:image/png;base64,{{ chart_data }}" alt="Chart">
+{% endif %}
+{% if table_html %}
+  <h2>Latest Data</h2>
+  {{ table_html|safe }}
+{% endif %}
+{% endblock %}

--- a/core/urls.py
+++ b/core/urls.py
@@ -1,6 +1,7 @@
 from django.urls import path
-from .views import stock_analysis_view
+from .views import stock_analysis_view, candlestick_analysis_view
 
 urlpatterns = [
     path('', stock_analysis_view, name='stock_analysis'),
+    path('candlestick/', candlestick_analysis_view, name='candlestick_analysis'),
 ]

--- a/core/views.py
+++ b/core/views.py
@@ -1,5 +1,5 @@
 from django.shortcuts import render
-from .analysis import analyze_stock
+from .analysis import analyze_stock, analyze_stock_candlestick
 
 
 def stock_analysis_view(request):
@@ -18,3 +18,21 @@ def stock_analysis_view(request):
         "table_html": table_html,
     }
     return render(request, "core/stock_analysis.html", context)
+
+
+def candlestick_analysis_view(request):
+    chart_data = None
+    table_html = None
+    ticker = ""
+
+    if request.method == "POST":
+        ticker = request.POST.get("ticker", "").strip()
+        if ticker:
+            chart_data, table_html = analyze_stock_candlestick(ticker)
+
+    context = {
+        "ticker": ticker,
+        "chart_data": chart_data,
+        "table_html": table_html,
+    }
+    return render(request, "core/candlestick_analysis.html", context)


### PR DESCRIPTION
## Summary
- create candlestick analysis function using mplfinance
- add new candlestick analysis view
- route `candlestick/` URL to the new view
- add template for the candlestick page

## Testing
- `python manage.py check` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_684552c3abb88329a3f777ca78c6af7e