### PR TITLE
Configure allowed hosts via env

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,9 @@ This is a simple Django project containing a single application `core`.
    railway init        # create Railway project
    railway add         # add Postgres plugin
    ```
-3. In the Railway dashboard, add the environment variables `SECRET_KEY`, `DATABASE_URL`, and `DEBUG`.
-4. If you plan to use [J-Quants](https://jpx-jquants.com/), sign up for a free account to obtain your API token and add it to the dashboard as `JQUANTS_TOKEN`. Otherwise, this variable can be omitted.
+3. In the Railway dashboard, add the environment variables `SECRET_KEY`, `DATABASE_URL`, `DEBUG`, and `ALLOWED_HOSTS`.
+4. `ALLOWED_HOSTS` accepts a comma-separated list of domain names and defaults to `*` if not set.
+5. If you plan to use [J-Quants](https://jpx-jquants.com/), sign up for a free account to obtain your API token and add it to the dashboard as `JQUANTS_TOKEN`. Otherwise, this variable can be omitted.
 
 ## Development
 

--- a/myapp/settings.py
+++ b/myapp/settings.py
@@ -32,7 +32,7 @@ SECRET_KEY = env("SECRET_KEY")
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = env("DEBUG")
 
-ALLOWED_HOSTS = []
+ALLOWED_HOSTS = env.list("ALLOWED_HOSTS", default=["*"])
 
 
 # Application definition


### PR DESCRIPTION
## Summary
- set `ALLOWED_HOSTS` using `django-environ`
- document the `ALLOWED_HOSTS` variable in Railway instructions

## Testing
- `python manage.py check` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68457d4b53dc832987d2ee94bd6cdedf