### PR TITLE
Update ALLOWED_HOSTS documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,9 @@ This is a simple Django project containing a single application `core`.
    railway add         # add Postgres plugin
    ```
 3. In the Railway dashboard, add the environment variables `SECRET_KEY`, `DATABASE_URL`, `DEBUG`, and `ALLOWED_HOSTS`.
-4. `ALLOWED_HOSTS` accepts a comma-separated list of domain names and defaults to `*` if not set.
-5. If you plan to use [J-Quants](https://jpx-jquants.com/), sign up for a free account to obtain your API token and add it to the dashboard as `JQUANTS_TOKEN`. Otherwise, this variable can be omitted.
+4. Set `ALLOWED_HOSTS` to a comma-separated list of domain names, such as `example.com`.
+5. The variable defaults to `*` if not provided.
+6. If you plan to use [J-Quants](https://jpx-jquants.com/), sign up for a free account to obtain your API token and add it to the dashboard as `JQUANTS_TOKEN`. Otherwise, this variable can be omitted.
 
 ## Development
 

--- a/myapp/settings.py
+++ b/myapp/settings.py
@@ -32,6 +32,7 @@ SECRET_KEY = env("SECRET_KEY")
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = env("DEBUG")
 
+# Allowed hosts configured via environment variable
 ALLOWED_HOSTS = env.list("ALLOWED_HOSTS", default=["*"])
 
 


### PR DESCRIPTION
## Summary
- document `ALLOWED_HOSTS` in `myapp/settings.py`
- expand README Railway instructions about `ALLOWED_HOSTS`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845831e1b3083299d08b655f0e14e14