### PR TITLE
Add analysis helpers and prediction view

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ This is a simple Django project containing a single application `core`.
    railway add         # add Postgres plugin
    ```
 3. In the Railway dashboard, add the environment variables `SECRET_KEY`, `DATABASE_URL`, `DEBUG`, and `ALLOWED_HOSTS`.
+   Set `SECRET_KEY` to `d^2$4jbvh*ihfkdupc(p#6q_i6trs!$x&&19+i*fj3hfh9u&cr`.
 4. Set `ALLOWED_HOSTS` to a comma-separated list of domain names, such as `example.com`.
 5. The variable defaults to `*` if not provided.
 6. If you plan to use [J-Quants](https://jpx-jquants.com/), sign up for a free account to obtain your API token and add it to the dashboard as `JQUANTS_TOKEN`. Otherwise, this variable can be omitted.
@@ -38,7 +39,7 @@ git commit -m "Initial commit"
 For local development, create a `.env` file and define your environment variables:
 
 ```bash
-SECRET_KEY=your-secret-key
+SECRET_KEY=d^2$4jbvh*ihfkdupc(p#6q_i6trs!$x&&19+i*fj3hfh9u&cr
 DATABASE_URL=your-database-url
 DEBUG=True
 ALLOWED_HOSTS=*

--- a/core/analysis.py
+++ b/core/analysis.py
@@ -78,3 +78,63 @@ def analyze_stock_candlestick(ticker: str):
     )
 
     return chart_data, table_html
+
+
+def generate_stock_plot(ticker: str):
+    """Return base64 encoded line plot for given ticker."""
+    ticker_symbol = f"{ticker}.T" if not ticker.endswith('.T') else ticker
+    df = yf.download(ticker_symbol, period="3mo", interval="1d")
+    if df.empty:
+        return None
+
+    df["MA20"] = df["Close"].rolling(window=20).mean()
+
+    plt.figure(figsize=(10, 5))
+    plt.plot(df.index, df["Close"], label="Close")
+    plt.plot(df.index, df["MA20"], label="MA20")
+    plt.legend()
+    plt.tight_layout()
+
+    buf = BytesIO()
+    plt.savefig(buf, format="png")
+    plt.close()
+    buf.seek(0)
+    return base64.b64encode(buf.getvalue()).decode("utf-8")
+
+
+def predict_next_move(ticker: str):
+    """Simple ML model predicting next day's move (UP/DOWN)."""
+    ticker_symbol = f"{ticker}.T" if not ticker.endswith('.T') else ticker
+    df = yf.download(ticker_symbol, period="2y", interval="1d")
+    if len(df) < 30:
+        return None
+
+    df["Return"] = df["Close"].pct_change()
+    for i in range(1, 6):
+        df[f"lag_{i}"] = df["Return"].shift(i)
+    df.dropna(inplace=True)
+
+    X = df[[f"lag_{i}" for i in range(1, 6)]]
+    y = (df["Return"] > 0).astype(int)
+
+    split = int(len(df) * 0.7)
+    X_train, X_test = X[:split], X[split:]
+    y_train, y_test = y[:split], y[split:]
+
+    from sklearn.linear_model import LogisticRegression
+
+    model = LogisticRegression(max_iter=200)
+    model.fit(X_train, y_train)
+
+    latest_features = X.iloc[[-1]]
+    prob = model.predict_proba(latest_features)[0, 1]
+    prediction = "UP" if prob >= 0.5 else "DOWN"
+
+    table = pd.DataFrame(
+        {
+            "Next Day": [df.index[-1] + pd.Timedelta(days=1)],
+            "Prediction": [prediction],
+            "Probability": [round(prob, 4)],
+        }
+    )
+    return table.to_html(classes="table table-striped", index=False)

--- a/core/templates/core/analysis.html
+++ b/core/templates/core/analysis.html
@@ -1,0 +1,16 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Stock Prediction</h1>
+<form method="get">
+  <input type="text" name="ticker" value="{{ ticker }}" placeholder="Ticker code">
+  <button type="submit">Analyze</button>
+</form>
+{% if chart_data %}
+  <h2>Chart</h2>
+  <img src="data:image/png;base64,{{ chart_data }}" alt="Chart">
+{% endif %}
+{% if prediction_table %}
+  <h2>Prediction</h2>
+  {{ prediction_table|safe }}
+{% endif %}
+{% endblock %}

--- a/core/urls.py
+++ b/core/urls.py
@@ -1,7 +1,8 @@
 from django.urls import path
-from .views import stock_analysis_view, candlestick_analysis_view
+from .views import analysis_view, stock_analysis_view, candlestick_analysis_view
 
 urlpatterns = [
-    path('', stock_analysis_view, name='stock_analysis'),
+    path('', analysis_view, name='analysis'),
+    path('stock/', stock_analysis_view, name='stock_analysis'),
     path('candlestick/', candlestick_analysis_view, name='candlestick_analysis'),
 ]

--- a/core/views.py
+++ b/core/views.py
@@ -1,5 +1,10 @@
 from django.shortcuts import render
-from .analysis import analyze_stock, analyze_stock_candlestick
+from .analysis import (
+    analyze_stock,
+    analyze_stock_candlestick,
+    generate_stock_plot,
+    predict_next_move,
+)
 
 
 def stock_analysis_view(request):
@@ -34,3 +39,19 @@ def candlestick_analysis_view(request):
         "table_html": table_html,
     }
     return render(request, "core/candlestick_analysis.html", context)
+
+
+def analysis_view(request):
+    chart_data = None
+    prediction_table = None
+    ticker = request.GET.get("ticker", "").strip()
+    if ticker:
+        chart_data = generate_stock_plot(ticker)
+        prediction_table = predict_next_move(ticker)
+
+    context = {
+        "ticker": ticker,
+        "chart_data": chart_data,
+        "prediction_table": prediction_table,
+    }
+    return render(request, "core/analysis.html", context)


### PR DESCRIPTION
## Summary
- add generate_stock_plot() and predict_next_move() helpers
- integrate new helpers in analysis_view and route
- show prediction table alongside chart
- document SECRET_KEY and ALLOWED_HOSTS env vars

## Testing
- `pip install -r requirements.txt`
- `python manage.py check`


------
https://chatgpt.com/codex/tasks/task_e_68459bc1ad548329b6430e763de6a23f