### PR TITLE
Add default DATABASE_URL and clarify deployment

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,4 @@
 SECRET_KEY=d^2$4jbvh*ihfkdupc(p#6q_i6trs!$x&&19+i*fj3hfh9u&cr
 DEBUG=True
+
+DATABASE_URL=sqlite:///db.sqlite3

--- a/README.md
+++ b/README.md
@@ -21,10 +21,11 @@ This is a simple Django project containing a single application `core`.
    railway add         # add Postgres plugin
    ```
 3. In the Railway dashboard, add the environment variables `SECRET_KEY`, `DATABASE_URL`, `DEBUG`, and `ALLOWED_HOSTS`.
+4. When deploying to Railway or any other host, the service should supply a proper `DATABASE_URL`. If not provided, the value from the `.env` file will be used.
    Set `SECRET_KEY` to `d^2$4jbvh*ihfkdupc(p#6q_i6trs!$x&&19+i*fj3hfh9u&cr`.
-4. Set `ALLOWED_HOSTS` to a comma-separated list of domain names, such as `example.com`.
-5. The variable defaults to `*` if not provided.
-6. If you plan to use [J-Quants](https://jpx-jquants.com/), sign up for a free account to obtain your API token and add it to the dashboard as `JQUANTS_TOKEN`. Otherwise, this variable can be omitted.
+5. Set `ALLOWED_HOSTS` to a comma-separated list of domain names, such as `example.com`.
+6. The variable defaults to `*` if not provided.
+7. If you plan to use [J-Quants](https://jpx-jquants.com/), sign up for a free account to obtain your API token and add it to the dashboard as `JQUANTS_TOKEN`. Otherwise, this variable can be omitted.
 
 ## Development
 


### PR DESCRIPTION
## Summary
- set DATABASE_URL in `.env` to use local SQLite by default
- note in README that hosting platforms should provide their own DATABASE_URL

## Testing
- `python manage.py migrate`

------
https://chatgpt.com/codex/tasks/task_e_6845af58933c8329989bf0842baaeba8