### PR TITLE
Add MACD/RSI chart and multi-day forecasts

### DIFF
--- a/core/analysis.py
+++ b/core/analysis.py
@@ -4,6 +4,7 @@ import matplotlib.pyplot as plt
 from io import BytesIO
 import base64
 import mplfinance as mpf
+import ta
 
 
 def analyze_stock(ticker: str):
@@ -42,7 +43,7 @@ def analyze_stock(ticker: str):
 
 
 def analyze_stock_candlestick(ticker: str):
-    """Generate candlestick chart with volume and MA lines."""
+    """Generate candlestick chart with volume, MACD, and RSI."""
     ticker_symbol = f"{ticker}.T" if not ticker.endswith('.T') else ticker
     df = yf.download(ticker_symbol, period="6mo", interval="1d")
     if df.empty:
@@ -51,18 +52,29 @@ def analyze_stock_candlestick(ticker: str):
     df["MA5"] = df["Close"].rolling(window=5).mean()
     df["MA25"] = df["Close"].rolling(window=25).mean()
     df["MA75"] = df["Close"].rolling(window=75).mean()
+    df["MACD"] = ta.trend.macd(df["Close"])
+    df["MACD_signal"] = ta.trend.macd_signal(df["Close"])
+    df["RSI"] = ta.momentum.rsi(df["Close"])
 
     plot_df = df[["Open", "High", "Low", "Close", "Volume"]].dropna().astype(float)
+
+    apds = [
+        mpf.make_addplot(df["MACD"], panel=2, color="blue", ylabel="MACD"),
+        mpf.make_addplot(df["MACD_signal"], panel=2, color="orange"),
+        mpf.make_addplot(df["RSI"], panel=3, color="purple", ylabel="RSI"),
+    ]
 
     fig, ax = mpf.plot(
         plot_df,
         type="candle",
         mav=(5, 25, 75),
         volume=True,
-        title=f"{ticker_symbol} Daily Candlestick and Volume (MA:5,25,75)",
+        addplot=apds,
+        title=f"{ticker_symbol} Daily Candlestick, MACD & RSI",
         style="yahoo",
         returnfig=True,
-        figsize=(12, 8),
+        figsize=(12, 10),
+        panel_ratios=(3, 1, 1, 1),
     )
 
     buf = BytesIO()
@@ -72,7 +84,7 @@ def analyze_stock_candlestick(ticker: str):
     chart_data = base64.b64encode(buf.getvalue()).decode("utf-8")
 
     table_html = (
-        df.tail(5)[["Close", "MA5", "MA25", "MA75"]]
+        df.tail(5)[["Close", "MA5", "MA25", "MA75", "MACD", "MACD_signal", "RSI"]]
         .round(2)
         .to_html(classes="table table-striped")
     )
@@ -138,3 +150,44 @@ def predict_next_move(ticker: str):
         }
     )
     return table.to_html(classes="table table-striped", index=False)
+
+
+def predict_future_moves(ticker: str):
+    """Predict stock direction for 1, 5 and 25 days ahead."""
+    ticker_symbol = f"{ticker}.T" if not ticker.endswith('.T') else ticker
+    df = yf.download(ticker_symbol, period="2y", interval="1d")
+    if len(df) < 30:
+        return None
+
+    df["Return"] = df["Close"].pct_change()
+    for i in range(1, 6):
+        df[f"lag_{i}"] = df["Return"].shift(i)
+    df.dropna(inplace=True)
+
+    X = df[[f"lag_{i}" for i in range(1, 6)]]
+    horizons = [1, 5, 25]
+    results = []
+    from sklearn.linear_model import LogisticRegression
+
+    for h in horizons:
+        df[f"target_{h}"] = (df["Close"].shift(-h) > df["Close"]).astype(int)
+        y = df[f"target_{h}"]
+        split = int(len(df) * 0.7)
+        model = LogisticRegression(max_iter=200)
+        model.fit(X[:split], y[:split])
+        prob = model.predict_proba(X.iloc[[-1]])[0, 1] * 100
+        prediction = "UP" if prob >= 50 else "DOWN"
+        results.append({
+            "Days Ahead": h,
+            "Prediction": prediction,
+            "Probability (%)": round(prob, 2),
+        })
+
+    table = pd.DataFrame(results)
+
+    def colorize(val: float) -> str:
+        color = "blue" if val > 50 else "red"
+        return f'<span style="color:{color}">{val:.2f}</span>'
+
+    table["Probability (%)"] = table["Probability (%)"].apply(colorize)
+    return table.to_html(classes="table table-striped", index=False, escape=False)

--- a/core/templates/core/candlestick_analysis.html
+++ b/core/templates/core/candlestick_analysis.html
@@ -13,4 +13,8 @@
   <h2>Latest Data</h2>
   {{ table_html|safe }}
 {% endif %}
+{% if prediction_table %}
+  <h2>Predictions</h2>
+  {{ prediction_table|safe }}
+{% endif %}
 {% endblock %}

--- a/core/tests.py
+++ b/core/tests.py
@@ -1,3 +1,13 @@
-from django.test import TestCase
+from django.test import SimpleTestCase
+from .analysis import analyze_stock_candlestick, predict_future_moves
 
-# Create your tests here.
+
+class AnalysisTests(SimpleTestCase):
+    def test_candlestick_chart_generation(self):
+        chart, table = analyze_stock_candlestick("7203")
+        self.assertIsNotNone(chart)
+        self.assertIsNotNone(table)
+
+    def test_prediction_generation(self):
+        table = predict_future_moves("7203")
+        self.assertIsNotNone(table)

--- a/core/views.py
+++ b/core/views.py
@@ -4,6 +4,7 @@ from .analysis import (
     analyze_stock_candlestick,
     generate_stock_plot,
     predict_next_move,
+    predict_future_moves,
 )
 
 
@@ -27,16 +28,19 @@ def stock_analysis_view(request):
 def candlestick_analysis_view(request):
     chart_data = None
     table_html = None
+    prediction_table = None
     ticker = ""
 
     ticker = request.GET.get("ticker", "").strip()
     if ticker:
         chart_data, table_html = analyze_stock_candlestick(ticker)
+        prediction_table = predict_future_moves(ticker)
 
     context = {
         "ticker": ticker,
         "chart_data": chart_data,
         "table_html": table_html,
+        "prediction_table": prediction_table,
     }
     return render(request, "core/candlestick_analysis.html", context)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ yfinance
 mplfinance
 matplotlib
 scikit-learn
+ta


### PR DESCRIPTION
## Summary
- extend candlestick chart to include MACD and RSI panels
- support multi-day predictions (1, 5, 25 days)
- show forecast table on candlestick page
- add `ta` to requirements
- basic tests for chart and prediction generation

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError ta resolved; but Yahoo Finance request blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68465bcd044c8329a54b60c7e6204b1b