### PR TITLE
Fix return value for insufficient data

### DIFF
--- a/core/analysis.py
+++ b/core/analysis.py
@@ -157,7 +157,7 @@ def predict_future_moves(ticker: str):
     ticker_symbol = f"{ticker}.T" if not ticker.endswith('.T') else ticker
     df = yf.download(ticker_symbol, period="2y", interval="1d")
     if len(df) < 30:
-        return None
+        return (None, None)
 
     df["Return"] = df["Close"].pct_change()
     for i in range(1, 6):


### PR DESCRIPTION
## Summary
- adjust early return in `predict_future_moves`

## Testing
- `python -m py_compile core/analysis.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846687491788329b5fd3cc432d75c44