### PR TITLE
Handle candlestick download failures

### DIFF
--- a/core/analysis.py
+++ b/core/analysis.py
@@ -39,15 +39,18 @@ def analyze_stock(ticker: str):
         .to_html(classes="table table-striped")
     )
 
-    return chart_data, table_html
+    return chart_data, table_html, None
 
 
 def analyze_stock_candlestick(ticker: str):
     """Generate candlestick chart with volume, MACD, and RSI."""
     ticker_symbol = f"{ticker}.T" if not ticker.endswith('.T') else ticker
-    df = yf.download(ticker_symbol, period="6mo", interval="1d", auto_adjust=False)
+    try:
+        df = yf.download(ticker_symbol, period="6mo", interval="1d", auto_adjust=False)
+    except Exception:
+        return None, None, "データ取得に失敗しました"
     if df.empty:
-        return None, None
+        return None, None, "データ取得に失敗しました"
 
     df["MA5"] = df["Close"].rolling(window=5).mean()
     df["MA25"] = df["Close"].rolling(window=25).mean()
@@ -89,7 +92,7 @@ def analyze_stock_candlestick(ticker: str):
         .to_html(classes="table table-striped")
     )
 
-    return chart_data, table_html
+    return chart_data, table_html, None
 
 
 def generate_stock_plot(ticker: str):

--- a/core/templates/core/candlestick_analysis.html
+++ b/core/templates/core/candlestick_analysis.html
@@ -5,6 +5,9 @@
   <input type="text" name="ticker" value="{{ ticker }}" placeholder="Ticker code">
   <button type="submit">Analyze</button>
 </form>
+{% if warning %}
+  <div class="alert alert-warning">{{ warning }}</div>
+{% endif %}
 {% if chart_data %}
   <h2>Chart</h2>
   <img src="data:image/png;base64,{{ chart_data }}" alt="Chart">

--- a/core/tests/test_analysis.py
+++ b/core/tests/test_analysis.py
@@ -18,7 +18,8 @@ SAMPLE_DF = pd.read_csv(FIXTURE_PATH, index_col="Date", parse_dates=True)
 class AnalysisTests(SimpleTestCase):
     @patch("yfinance.download", return_value=SAMPLE_DF.copy())
     def test_candlestick_chart_generation(self, mock_download):
-        chart, table = analyze_stock_candlestick("7203")
+        chart, table, warning = analyze_stock_candlestick("7203")
+        self.assertIsNone(warning)
         self.assertTrue(chart.startswith("iVBOR"))
         self.assertIn("<table", table)
 

--- a/core/views.py
+++ b/core/views.py
@@ -30,12 +30,14 @@ def candlestick_analysis_view(request):
     table_html = None
     prediction_table = None
     features_table = None
+    warning = None
     ticker = ""
 
     ticker = request.GET.get("ticker", "").strip()
     if ticker:
-        chart_data, table_html = analyze_stock_candlestick(ticker)
-        prediction_table, features_table = predict_future_moves(ticker)
+        chart_data, table_html, warning = analyze_stock_candlestick(ticker)
+        if warning is None:
+            prediction_table, features_table = predict_future_moves(ticker)
 
     context = {
         "ticker": ticker,
@@ -43,6 +45,7 @@ def candlestick_analysis_view(request):
         "table_html": table_html,
         "prediction_table": prediction_table,
         "features_table": features_table,
+        "warning": warning,
     }
     return render(request, "core/candlestick_analysis.html", context)
 


### PR DESCRIPTION
## Summary
- add error handling for candlestick data download
- return warning message from `analyze_stock_candlestick`
- show the warning in candlestick view and template
- update tests for new return signature

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68467a57d90483298b2a09cb689d757b