### PR TITLE
Fix MultiIndex handling in candlestick analysis

### DIFF
--- a/core/analysis.py
+++ b/core/analysis.py
@@ -52,6 +52,8 @@ def analyze_stock_candlestick(ticker: str):
             interval="1d",
             auto_adjust=False,
         )
+        if isinstance(stock_data.columns, pd.MultiIndex):
+            stock_data.columns = stock_data.columns.droplevel(0)
     except Exception:
         return None, None, "データ取得に失敗しました"
     if stock_data.empty:


### PR DESCRIPTION
## Summary
- handle MultiIndex column names when downloading stock data

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846def2fd448329a2fa2dfcc4f81486