### PR TITLE
Handle two tickers in candlestick analysis

### DIFF
--- a/core/templates/core/candlestick_analysis.html
+++ b/core/templates/core/candlestick_analysis.html
@@ -1,28 +1,61 @@
 {% extends 'base.html' %}
 {% block content %}
 <h1>Candlestick Analysis</h1>
-<form method="get">
-  <input type="text" name="ticker" value="{{ ticker }}" placeholder="Ticker code">
-  <button type="submit">Analyze</button>
+<form method="get" class="row g-2 mb-3">
+  <div class="col-md-5">
+    <input type="text" class="form-control" name="ticker1" value="{{ ticker1 }}" placeholder="Ticker code 1">
+  </div>
+  <div class="col-md-5">
+    <input type="text" class="form-control" name="ticker2" value="{{ ticker2 }}" placeholder="Ticker code 2">
+  </div>
+  <div class="col-md-2">
+    <button type="submit" class="btn btn-primary w-100">Analyze</button>
+  </div>
 </form>
-{% if warning %}
-  <div class="alert alert-warning">{{ warning }}</div>
-{% endif %}
-{% if chart_data %}
-  <h2>Chart</h2>
-  <img src="data:image/png;base64,{{ chart_data }}" alt="Chart">
-{% endif %}
-{% if table_html %}
-  <h2>Latest Data</h2>
-  {{ table_html|safe }}
-{% endif %}
-{% if prediction_table %}
-  <h2>Predictions</h2>
-  {{ prediction_table|safe }}
-  <p class="small text-muted">Probability (%) は翌営業日に株価が上昇する確率です。</p>
-{% endif %}
-{% if importance_table %}
-  <h2>Feature Importance</h2>
-  {{ importance_table|safe }}
-{% endif %}
+<div class="row">
+  <div class="col-md-6">
+    {% if data1.warning %}
+      <div class="alert alert-warning">{{ data1.warning }}</div>
+    {% endif %}
+    {% if data1.chart_data %}
+      <h2>{{ ticker1 }}</h2>
+      <img src="data:image/png;base64,{{ data1.chart_data }}" alt="Chart" class="img-fluid">
+    {% endif %}
+    {% if data1.table_html %}
+      <h3>Latest Data</h3>
+      {{ data1.table_html|safe }}
+    {% endif %}
+    {% if data1.prediction_table %}
+      <h3>Predictions</h3>
+      {{ data1.prediction_table|safe }}
+      <p class="small text-muted">Probability (%) は翌営業日に株価が上昇する確率です。</p>
+    {% endif %}
+    {% if data1.importance_table %}
+      <h3>Feature Importance</h3>
+      {{ data1.importance_table|safe }}
+    {% endif %}
+  </div>
+  <div class="col-md-6">
+    {% if data2.warning %}
+      <div class="alert alert-warning">{{ data2.warning }}</div>
+    {% endif %}
+    {% if data2.chart_data %}
+      <h2>{{ ticker2 }}</h2>
+      <img src="data:image/png;base64,{{ data2.chart_data }}" alt="Chart" class="img-fluid">
+    {% endif %}
+    {% if data2.table_html %}
+      <h3>Latest Data</h3>
+      {{ data2.table_html|safe }}
+    {% endif %}
+    {% if data2.prediction_table %}
+      <h3>Predictions</h3>
+      {{ data2.prediction_table|safe }}
+      <p class="small text-muted">Probability (%) は翌営業日に株価が上昇する確率です。</p>
+    {% endif %}
+    {% if data2.importance_table %}
+      <h3>Feature Importance</h3>
+      {{ data2.importance_table|safe }}
+    {% endif %}
+  </div>
+</div>
 {% endblock %}

--- a/core/tests/test_analysis.py
+++ b/core/tests/test_analysis.py
@@ -72,3 +72,19 @@ class AnalysisTests(SimpleTestCase):
         mock_analyze.assert_called_once_with("7203")
         self.assertIn("chart", response.content.decode())
         self.assertIn("<table", response.content.decode())
+
+    @patch("core.views.predict_future_moves")
+    @patch("core.views.analyze_stock_candlestick")
+    def test_candlestick_view_handles_two_tickers(self, mock_analyze, mock_predict):
+        mock_analyze.return_value = ("chart", "<table></table>", None)
+        mock_predict.return_value = ("<table></table>", "<table></table>")
+        response = self.client.get(
+            "/candlestick/?ticker1=7203&ticker2=6758", HTTP_HOST="localhost"
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(mock_analyze.call_count, 2)
+        mock_analyze.assert_any_call("7203")
+        mock_analyze.assert_any_call("6758")
+        self.assertEqual(mock_predict.call_count, 2)
+        content = response.content.decode()
+        self.assertIn("chart", content)

--- a/core/views.py
+++ b/core/views.py
@@ -26,26 +26,33 @@ def stock_analysis_view(request):
 
 
 def candlestick_analysis_view(request):
-    chart_data = None
-    table_html = None
-    prediction_table = None
-    importance_table = None
-    warning = None
-    ticker = ""
+    ticker1 = request.GET.get("ticker1", "").strip()
+    ticker2 = request.GET.get("ticker2", "").strip()
 
-    ticker = request.GET.get("ticker", "").strip()
-    if ticker:
+    def fetch_data(ticker: str):
+        if not ticker:
+            return {}
         chart_data, table_html, warning = analyze_stock_candlestick(ticker)
+        prediction_table = None
+        importance_table = None
         if warning is None:
             prediction_table, importance_table = predict_future_moves(ticker)
+        return {
+            "chart_data": chart_data,
+            "table_html": table_html,
+            "prediction_table": prediction_table,
+            "importance_table": importance_table,
+            "warning": warning,
+        }
+
+    data1 = fetch_data(ticker1)
+    data2 = fetch_data(ticker2)
 
     context = {
-        "ticker": ticker,
-        "chart_data": chart_data,
-        "table_html": table_html,
-        "prediction_table": prediction_table,
-        "importance_table": importance_table,
-        "warning": warning,
+        "ticker1": ticker1,
+        "ticker2": ticker2,
+        "data1": data1,
+        "data2": data2,
     }
     return render(request, "core/candlestick_analysis.html", context)
 


### PR DESCRIPTION
## Summary
- update candlestick view to support two tickers
- redesign candlestick template into a two-column layout
- test that the view processes two tickers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846ef195ce48329ae6f781bba787c70