### PR TITLE
UI improvements for candlestick view

### DIFF
--- a/core/templates/core/candlestick_analysis.html
+++ b/core/templates/core/candlestick_analysis.html
@@ -1,35 +1,34 @@
 {% extends 'base.html' %}
 {% block content %}
 <h1>Candlestick Analysis</h1>
-<form method="get" class="row g-2 mb-3">
-  <div class="col-md-5">
-    <input type="text" class="form-control" name="ticker1" value="{{ ticker1 }}" placeholder="Ticker code 1">
-  </div>
-  <div class="col-md-5">
-    <input type="text" class="form-control" name="ticker2" value="{{ ticker2 }}" placeholder="Ticker code 2">
-  </div>
-  <div class="col-md-2">
-    <button type="submit" class="btn btn-primary w-100">Analyze</button>
-  </div>
-</form>
-<div class="row">
-  <div class="col-md-6">
+  <form method="get" class="row g-2 mb-3">
+    <div class="col-md-3">
+      <input type="text" class="form-control" name="ticker1" value="{{ ticker1 }}" placeholder="Ticker code 1">
+    </div>
+    <div class="col-md-3">
+      <input type="text" class="form-control" name="ticker2" value="{{ ticker2 }}" placeholder="Ticker code 2">
+    </div>
+    <div class="col-md-2">
+      <button type="submit" class="btn btn-primary w-100">Analyze</button>
+    </div>
+  </form>
+  <div class="row">
+    <div class="col-md-6">
     {% if data1.warning %}
       <div class="alert alert-warning">{{ data1.warning }}</div>
     {% endif %}
-    {% if data1.chart_data %}
-      <h2>{{ ticker1 }}</h2>
-      <img src="data:image/png;base64,{{ data1.chart_data }}" alt="Chart" class="img-fluid">
-    {% endif %}
+      {% if data1.chart_data %}
+        <h2>{{ company1|default:ticker1 }}</h2>
+        <img src="data:image/png;base64,{{ data1.chart_data }}" alt="Chart" class="img-fluid w-100">
+      {% endif %}
     {% if data1.table_html %}
       <h3>Latest Data</h3>
       {{ data1.table_html|safe }}
     {% endif %}
-    {% if data1.prediction_table %}
-      <h3>Predictions</h3>
-      {{ data1.prediction_table|safe }}
-      <p class="small text-muted">Probability (%) は翌営業日に株価が上昇する確率です。</p>
-    {% endif %}
+      {% if data1.prediction_table %}
+        <h3>Predictions</h3>
+        {{ data1.prediction_table|safe }}
+      {% endif %}
     {% if data1.importance_table %}
       <h3>Feature Importance</h3>
       {{ data1.importance_table|safe }}
@@ -39,19 +38,18 @@
     {% if data2.warning %}
       <div class="alert alert-warning">{{ data2.warning }}</div>
     {% endif %}
-    {% if data2.chart_data %}
-      <h2>{{ ticker2 }}</h2>
-      <img src="data:image/png;base64,{{ data2.chart_data }}" alt="Chart" class="img-fluid">
-    {% endif %}
+      {% if data2.chart_data %}
+        <h2>{{ company2|default:ticker2 }}</h2>
+        <img src="data:image/png;base64,{{ data2.chart_data }}" alt="Chart" class="img-fluid w-100">
+      {% endif %}
     {% if data2.table_html %}
       <h3>Latest Data</h3>
       {{ data2.table_html|safe }}
     {% endif %}
-    {% if data2.prediction_table %}
-      <h3>Predictions</h3>
-      {{ data2.prediction_table|safe }}
-      <p class="small text-muted">Probability (%) は翌営業日に株価が上昇する確率です。</p>
-    {% endif %}
+      {% if data2.prediction_table %}
+        <h3>Predictions</h3>
+        {{ data2.prediction_table|safe }}
+      {% endif %}
     {% if data2.importance_table %}
       <h3>Feature Importance</h3>
       {{ data2.importance_table|safe }}

--- a/core/views.py
+++ b/core/views.py
@@ -5,6 +5,7 @@ from .analysis import (
     generate_stock_plot,
     predict_next_move,
     predict_future_moves,
+    get_company_name,
 )
 
 
@@ -35,6 +36,7 @@ def candlestick_analysis_view(request):
         chart_data, table_html, warning = analyze_stock_candlestick(ticker)
         prediction_table = None
         importance_table = None
+        company_name = get_company_name(ticker)
         if warning is None:
             prediction_table, importance_table = predict_future_moves(ticker)
         return {
@@ -43,6 +45,7 @@ def candlestick_analysis_view(request):
             "prediction_table": prediction_table,
             "importance_table": importance_table,
             "warning": warning,
+            "company_name": company_name,
         }
 
     data1 = fetch_data(ticker1)
@@ -53,6 +56,8 @@ def candlestick_analysis_view(request):
         "ticker2": ticker2,
         "data1": data1,
         "data2": data2,
+        "company1": data1.get("company_name"),
+        "company2": data2.get("company_name"),
     }
     return render(request, "core/candlestick_analysis.html", context)
 


### PR DESCRIPTION
## Summary
- shrink ticker input boxes and widen charts
- show company names above charts
- round latest-data values to integers
- display prediction probability as percentage

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_684755acd8d083298f182faeb603a197