### PR TITLE
Add multi-horizon stock prediction

### DIFF
--- a/core/tests/test_analysis.py
+++ b/core/tests/test_analysis.py
@@ -37,6 +37,7 @@ class AnalysisTests(SimpleTestCase):
         self.assertIn("<table", prediction_html)
         self.assertIn("<table", importance_html)
         self.assertIn("Prediction", prediction_html)
+        self.assertIn("期待リターン", prediction_html)
         self.assertIn("Feature", importance_html)
         self.assertIn("Importance", importance_html)
 

--- a/core/views.py
+++ b/core/views.py
@@ -3,8 +3,8 @@ from .analysis import (
     analyze_stock,
     analyze_stock_candlestick,
     generate_stock_plot,
-    predict_next_move,
     predict_future_moves,
+    predict_next_move,
     get_company_name,
 )
 
@@ -68,7 +68,7 @@ def analysis_view(request):
     ticker = request.GET.get("ticker", "").strip()
     if ticker:
         chart_data = generate_stock_plot(ticker)
-        prediction_table = predict_next_move(ticker)
+        prediction_table, _ = predict_future_moves(ticker)
 
     context = {
         "ticker": ticker,


### PR DESCRIPTION
## Summary
- handle NaN when generating tables
- support predictions for +1, +7 and +28 days
- compute expected return for UP and DOWN predictions
- show new table in analysis view
- update tests

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684757b82f3c83299b05b06fd47089d2