### PR TITLE
Improve prediction table styling

### DIFF
--- a/core/analysis.py
+++ b/core/analysis.py
@@ -233,15 +233,18 @@ def predict_future_moves(ticker: str, horizons=None):
     table = pd.DataFrame(results)
     prob_col = "上昇確率"
 
-    def highlight(val: float) -> str:
-        if val >= 70:
-            return "background-color: lightgreen"
-        elif val <= 30:
-            return "background-color: lightcoral"
-        return ""
+    def color_scale(val: float) -> str:
+        if val == 50:
+            return ""
+        if val > 50:
+            alpha = min((val - 50) / 50, 1)
+            return f"background-color: rgba(0, 255, 0, {alpha:.2f})"
+        alpha = min((50 - val) / 50, 1)
+        return f"background-color: rgba(255, 0, 0, {alpha:.2f})"
 
     styled_table = (
-        table.style.applymap(highlight, subset=[prob_col])
+        table.style.applymap(color_scale, subset=[prob_col])
+        .format({prob_col: "{:.0f}%", "期待リターン": lambda x: f"{x:+.2f}%"})
         .hide(axis="index")
         .set_table_attributes('class="table table-striped"')
     )

--- a/core/templates/core/candlestick_analysis.html
+++ b/core/templates/core/candlestick_analysis.html
@@ -29,10 +29,6 @@
         <h3>Predictions</h3>
         {{ data1.prediction_table|safe }}
       {% endif %}
-    {% if data1.importance_table %}
-      <h3>Feature Importance</h3>
-      {{ data1.importance_table|safe }}
-    {% endif %}
   </div>
   <div class="col-md-6">
     {% if data2.warning %}
@@ -50,10 +46,6 @@
         <h3>Predictions</h3>
         {{ data2.prediction_table|safe }}
       {% endif %}
-    {% if data2.importance_table %}
-      <h3>Feature Importance</h3>
-      {{ data2.importance_table|safe }}
-    {% endif %}
   </div>
 </div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add color scale styling for probability cells
- format expected return with sign and percent
- remove feature importance table from candlestick page

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68475b64d7088329b71775ac2282339b