### PR TITLE
Update candlestick view with financials

### DIFF
--- a/core/templates/core/candlestick_analysis.html
+++ b/core/templates/core/candlestick_analysis.html
@@ -25,6 +25,10 @@
       <h3>Latest Data</h3>
       {{ data1.table_html|safe }}
     {% endif %}
+    {% if data1.fund_table_html %}
+      <h3>Financials</h3>
+      {{ data1.fund_table_html|safe }}
+    {% endif %}
       {% if data1.prediction_table %}
         <h3>Predictions</h3>
         {{ data1.prediction_table|safe }}
@@ -41,6 +45,10 @@
     {% if data2.table_html %}
       <h3>Latest Data</h3>
       {{ data2.table_html|safe }}
+    {% endif %}
+    {% if data2.fund_table_html %}
+      <h3>Financials</h3>
+      {{ data2.fund_table_html|safe }}
     {% endif %}
       {% if data2.prediction_table %}
         <h3>Predictions</h3>

--- a/core/views.py
+++ b/core/views.py
@@ -6,6 +6,7 @@ from .analysis import (
     predict_future_moves,
     predict_next_move,
     get_company_name,
+    _load_financial_metrics,
 )
 
 
@@ -36,14 +37,19 @@ def candlestick_analysis_view(request):
         chart_data, table_html, warning = analyze_stock_candlestick(ticker)
         prediction_table = None
         company_name = get_company_name(ticker)
+        fund_table_html = None
         if warning is None:
             prediction_table, _ = predict_future_moves(ticker)
+        fund_df = _load_financial_metrics(ticker)
+        if not fund_df.empty:
+            fund_table_html = fund_df.to_html(classes="table table-striped")
         return {
             "chart_data": chart_data,
             "table_html": table_html,
             "prediction_table": prediction_table,
             "warning": warning,
             "company_name": company_name,
+            "fund_table_html": fund_table_html,
         }
 
     data1 = fetch_data(ticker1)


### PR DESCRIPTION
## Summary
- truncate company names in `get_company_name`
- add `_load_financial_metrics` helper
- enhance candlestick analysis with PER/PBR merge and larger figure
- show financial tables in candlestick view
- cover new behaviour with tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68500a506fdc832982862f6bf9a1e96a