### PR TITLE
Add fundamentals index normalisation

### DIFF
--- a/core/analysis.py
+++ b/core/analysis.py
@@ -51,6 +51,9 @@ def _load_fundamentals(ticker_symbol: str) -> pd.DataFrame:
             pb = pd.Series(pb_value, index=eps_q.index)
         df_fund = pd.DataFrame({"eps": eps_q, "pe": pe, "pb": pb})
         df_fund.index = df_fund.index + timedelta(days=1)
+        df_fund.index.name = "date"
+        df_fund = df_fund.reset_index()
+        df_fund = df_fund.set_index("date")
         return df_fund
     except Exception:
         return pd.DataFrame()


### PR DESCRIPTION
## Summary
- adjust `_load_fundamentals` to set index name
- reset and re-set the index for better date handling

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68504551f3488329a07fb88122241563