### PR TITLE
Support MultiIndex in predict_future_moves

### DIFF
--- a/core/analysis.py
+++ b/core/analysis.py
@@ -262,6 +262,14 @@ def predict_future_moves(ticker: str, horizons=None):
         return (None, None)
 
     fund = _load_fundamentals(ticker_symbol)
+    if isinstance(df.index, pd.MultiIndex):
+        df.index = df.index.get_level_values(0)
+    if isinstance(fund.index, pd.MultiIndex):
+        fund.index = fund.index.get_level_values(0)
+
+    df.index = pd.to_datetime(df.index)
+    fund.index = pd.to_datetime(fund.index)
+
     df.index.name = "date"
     fund.index.name = "date"
     df = (

--- a/core/tests/test_analysis.py
+++ b/core/tests/test_analysis.py
@@ -145,3 +145,15 @@ class AnalysisTests(SimpleTestCase):
         self.assertTrue(isinstance(df.index, pd.DatetimeIndex))
         self.assertEqual(df.index.nlevels, 1)
 
+    @patch("core.analysis._load_fundamentals", return_value=SAMPLE_FUND.copy())
+    @patch("yfinance.download")
+    def test_predict_future_moves_handles_multiindex_prices(self, mock_download, mock_fund):
+        mi = pd.MultiIndex.from_product([SAMPLE_DF.index, ["A"]])
+        df = SAMPLE_DF.copy()
+        df.index = mi
+        mock_download.return_value = df
+
+        html, result_none = predict_future_moves("7203")
+        self.assertIn("<table", html)
+        self.assertIsNone(result_none)
+


### PR DESCRIPTION
## Summary
- handle MultiIndex indices in `predict_future_moves`
- convert indices to datetime before merging
- test MultiIndex from `yf.download`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852789999a483298629c586f6db4547