### PR TITLE
Simplify fundamentals merge

### DIFF
--- a/core/analysis.py
+++ b/core/analysis.py
@@ -268,11 +268,7 @@ def predict_future_moves(ticker: str, horizons=None):
 
     df.index.name = "date"
     fund.index.name = "date"
-    df = (
-        df.reset_index()
-        .merge(fund.reset_index(), on="date", how="left")
-        .set_index("date")
-    )
+    df = df.merge(fund, left_index=True, right_index=True, how="left")
     if fund.empty:
         df[["eps", "pe", "pb"]] = df[["Close"]].pct_change() * 0
         df[["eps", "pe", "pb"]].fillna(0, inplace=True)


### PR DESCRIPTION
## Summary
- keep fundamentals and price data indexes simple
- merge fundamental info with price data by index

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852aa3b7d748329ad76b76dc12f8a50