### PR TITLE
Fix index merge in predict_future_moves

### DIFF
--- a/core/analysis.py
+++ b/core/analysis.py
@@ -268,7 +268,10 @@ def predict_future_moves(ticker: str, horizons=None):
 
     df.index.name = "date"
     fund.index.name = "date"
-    df = df.merge(fund, left_index=True, right_index=True, how="left")
+    df = df.reset_index()
+    fund = fund.reset_index()
+    df = df.merge(fund, on="date", how="left")
+    df = df.set_index("date")
     if fund.empty:
         df[["eps", "pe", "pb"]] = df[["Close"]].pct_change() * 0
         df[["eps", "pe", "pb"]].fillna(0, inplace=True)


### PR DESCRIPTION
## Summary
- fix dataframe merge to use a column rather than multiindex for `predict_future_moves`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852aed64d408329a91d4363df86f4e3