### PR TITLE
Add Gemini analyst integration

### DIFF
--- a/core/gemini_analyzer.py
+++ b/core/gemini_analyzer.py
@@ -1,0 +1,71 @@
+import google.generativeai as genai
+import os
+import pandas as pd
+
+# 環境変数からAPIキーを設定
+api_key = os.environ.get("GEMINI_API_KEY")
+if api_key:
+    genai.configure(api_key=api_key)
+else:
+    print("Warning: GEMINI_API_KEY is not set.")
+
+
+def generate_analyst_report(
+    ticker_name,
+    ticker_code,
+    latest_data_html,
+    predictions_html,
+):
+    """Takes stock data and predictions, queries the Gemini API,
+    and returns a formatted analysis report."""
+    if not api_key:
+        return (
+            "Gemini API key is not configured. "
+            "Please set the GEMINI_API_KEY environment variable."
+        )
+
+    # HTMLテーブルをシンプルなテキストに変換（簡易版）
+    try:
+        latest_data = pd.read_html(latest_data_html)[0].to_string()
+        predictions = pd.read_html(predictions_html)[0].to_string()
+    except Exception:
+        latest_data = "N/A"
+        predictions = "N/A"
+
+    prompt = f"""
+あなたはプロの証券アナリストです。テクニカル分析とファンダメンタルズ分析の両方に精通しており、客観的なデータに基づき、冷静かつ的確な投資判断を下すことを得意としています。
+これから、私のアシスタントとして、特定の銘柄に関する分析レポートを作成してください。
+
+### 分析対象銘柄
+- 銘柄名: {ticker_name}
+- 銘柄コード: {ticker_code}
+
+### 【データ1】テクニカル指標とモデルによる予測
+{latest_data}
+{predictions}
+
+### 【データ2】最新のファンダメンタルズ情報（Web検索）
+- **指示:** あなた自身の能力（Webブラウジング機能）を使って、この銘柄の直近の決算発表の内容を調べてください。
+- **調査項目:**
+    - 最新の四半期の「売上高」「営業利益」は、市場コンセンサス予想と比較してどうでしたか？
+    - 通期の業績見通しに変更はありましたか？
+    - 経営陣が強調している、今後のビジネスの追い風や逆風は何ですか？
+
+### 【あなたのタスク】総合分析レポートの作成
+以下の構成でレポートを作成してください。
+
+1. **サマリー（3行で要約）**
+2. **テクニカル分析**
+3. **ファンダメンタルズ分析**
+4. **総合的な投資判断と戦略**
+   - **推奨アクションプラン**（推奨買値、推奨売値、時間軸）
+
+プロフェッショナルとして、客観的かつ論理的な分析を期待しています。
+"""
+
+    try:
+        model = genai.GenerativeModel('gemini-1.5-flash')
+        response = model.generate_content(prompt)
+        return response.text
+    except Exception as e:
+        return f"Error generating report from Gemini: {e}"

--- a/core/templates/core/main_analysis.html
+++ b/core/templates/core/main_analysis.html
@@ -34,6 +34,7 @@
       {% if data1.prediction_table %}
         <h3>Predictions</h3>
         {{ data1.prediction_table|safe }}
+        {{ data1.gemini_report|linebreaks }}
       {% endif %}
   </div>
   <div class="col-md-6">
@@ -57,6 +58,7 @@
       {% if data2.prediction_table %}
         <h3>Predictions</h3>
         {{ data2.prediction_table|safe }}
+        {{ data2.gemini_report|linebreaks }}
       {% endif %}
   </div>
 </div>

--- a/core/views.py
+++ b/core/views.py
@@ -5,6 +5,7 @@ from .analysis import (
     predict_future_moves,
     _load_and_format_financials,
 )
+from .gemini_analyzer import generate_analyst_report
 
 # Legacy attributes kept for test compatibility
 _load_financial_metrics = None
@@ -23,15 +24,24 @@ def fetch_data(ticker):
     quarterly_table = _load_and_format_financials(ticker, "quarterly")
     annual_table = _load_and_format_financials(ticker, "annual")
 
+    company_name = get_company_name(ticker)
+    gemini_report = generate_analyst_report(
+        company_name,
+        ticker,
+        latest_data_table or "",
+        prediction_table or "",
+    )
+
     return {
         "ticker": ticker,
-        "company_name": get_company_name(ticker),
+        "company_name": company_name,
         "chart_data": chart_data,
         "latest_data_table": latest_data_table,
         "prediction_table": prediction_table,
         "quarterly_table": quarterly_table,
         "annual_table": annual_table,
         "warning": warning,
+        "gemini_report": gemini_report,
     }
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ pytest
 jinja2
 lightgbm
 flake8
+google-generativeai


### PR DESCRIPTION
## Summary
- install `google-generativeai`
- implement `generate_analyst_report` in `gemini_analyzer`
- integrate Gemini report generation in `fetch_data`
- show AI analyst report on analysis page

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6857d282512c83299e1a1cbfd81ea4bb