### PR TITLE
Add ticker search modal

### DIFF
--- a/core/analysis.py
+++ b/core/analysis.py
@@ -24,6 +24,18 @@ TICKER_NAMES = {
     "9104.T": "商船三井",
 }
 
+INDUSTRY_TICKER_MAP = {
+    "自動車": {"7203": "トヨタ自動車", "7203.T": "トヨタ自動車"},
+    "電機": {"6758": "ソニーグループ", "6758.T": "ソニーグループ"},
+    "金融": {"8591": "オリックス", "8591.T": "オリックス"},
+    "海運": {
+        "9101": "日本郵船",
+        "9101.T": "日本郵船",
+        "9104": "商船三井",
+        "9104.T": "商船三井",
+    },
+}
+
 
 def _get_first_non_empty(tkr: yf.Ticker, attrs: list[str]) -> pd.DataFrame:
     """Return the first non-empty DataFrame among ticker attributes."""
@@ -332,7 +344,7 @@ def analyze_stock_candlestick(ticker: str):
 
     tbl_cols = ["Close", "MACD", "RSI", "eps", "pe"]
     table_df = stock_data.tail(5)[tbl_cols].round(0)
-    table_df = table_df.applymap(lambda x: "-" if pd.isna(x) else int(x))
+    table_df = table_df.map(lambda x: "-" if pd.isna(x) else int(x))
     table_html = table_df.reset_index().rename(columns={"index": "date"}).to_html(
         classes="table table-striped", index=False
     )

--- a/core/templates/base.html
+++ b/core/templates/base.html
@@ -9,5 +9,6 @@
 <div class="container mt-4">
 {% block content %}{% endblock %}
 </div>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
 </body>
 </html>

--- a/core/templates/core/main_analysis.html
+++ b/core/templates/core/main_analysis.html
@@ -1,17 +1,35 @@
 {% extends 'base.html' %}
+{% load json_extras %}
 {% block content %}
 <h1>Candlestick Analysis</h1>
   <form method="get" class="row g-2 mb-3">
     <div class="col-md-3">
-      <input type="text" class="form-control" name="ticker1" value="{{ ticker1 }}" placeholder="Ticker code 1">
+      <input type="text" class="form-control" id="ticker1" name="ticker1" value="{{ ticker1 }}" placeholder="Ticker code 1">
+    </div>
+    <div class="col-md-1">
+      <button type="button" class="btn btn-outline-secondary ticker-btn" data-bs-toggle="modal" data-bs-target="#tickerModal" data-input="#ticker1">銘柄検索</button>
     </div>
     <div class="col-md-3">
-      <input type="text" class="form-control" name="ticker2" value="{{ ticker2 }}" placeholder="Ticker code 2">
+      <input type="text" class="form-control" id="ticker2" name="ticker2" value="{{ ticker2 }}" placeholder="Ticker code 2">
+    </div>
+    <div class="col-md-1">
+      <button type="button" class="btn btn-outline-secondary ticker-btn" data-bs-toggle="modal" data-bs-target="#tickerModal" data-input="#ticker2">銘柄検索</button>
     </div>
     <div class="col-md-2">
       <button type="submit" class="btn btn-primary w-100">Analyze</button>
     </div>
   </form>
+  <div class="modal fade" id="tickerModal" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-scrollable">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title">銘柄検索</h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+        </div>
+        <div class="modal-body"></div>
+      </div>
+    </div>
+  </div>
   <div class="row">
     <div class="col-md-6">
     {% if data1.warning %}
@@ -62,4 +80,39 @@
       {% endif %}
   </div>
 </div>
+<script>
+  const industryMap = {{ industry_map | tojson | safe }};
+  const tickerModal = document.getElementById('tickerModal');
+  let activeInput = null;
+  document.querySelectorAll('.ticker-btn').forEach(btn => {
+    btn.addEventListener('click', () => {
+      activeInput = document.querySelector(btn.dataset.input);
+    });
+  });
+  tickerModal.addEventListener('show.bs.modal', () => {
+    const body = tickerModal.querySelector('.modal-body');
+    body.innerHTML = '';
+    for (const [industry, tickers] of Object.entries(industryMap)) {
+      const block = document.createElement('div');
+      block.classList.add('mb-2');
+      const heading = document.createElement('h6');
+      heading.textContent = industry;
+      block.appendChild(heading);
+      for (const [ticker, name] of Object.entries(tickers)) {
+        const b = document.createElement('button');
+        b.type = 'button';
+        b.className = 'btn btn-sm btn-outline-primary m-1';
+        b.textContent = `${ticker} ${name}`;
+        b.addEventListener('click', () => {
+          if (activeInput) {
+            activeInput.value = ticker;
+          }
+          bootstrap.Modal.getInstance(tickerModal).hide();
+        });
+        block.appendChild(b);
+      }
+      body.appendChild(block);
+    }
+  });
+</script>
 {% endblock %}

--- a/core/templatetags/json_extras.py
+++ b/core/templatetags/json_extras.py
@@ -1,0 +1,9 @@
+import json
+from django import template
+
+register = template.Library()
+
+
+@register.filter
+def tojson(value):
+    return json.dumps(value, ensure_ascii=False)

--- a/core/views.py
+++ b/core/views.py
@@ -7,6 +7,7 @@ from .analysis import (
     analyze_stock_candlestick,
     predict_future_moves,
     _load_and_format_financials,
+    INDUSTRY_TICKER_MAP,
 )
 from .gemini_analyzer import generate_analyst_report
 
@@ -73,5 +74,6 @@ def main_analysis_view(request):
         "ticker2": ticker2,
         "data1": data1,
         "data2": data2,
+        "industry_map": INDUSTRY_TICKER_MAP,
     }
     return render(request, "core/main_analysis.html", context)


### PR DESCRIPTION
## Summary
- map industries to tickers for easy search
- expose industry map in main view
- include Bootstrap JS for modal support
- add search buttons with modal and dynamic JS
- replace deprecated pandas usage
- provide `tojson` filter for templates

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68582fcd0f1083299a129067e9b63184