### PR TITLE
JPX プライム銘柄リスト自動生成スクリプト

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ ENV/
 .DS_Store
 *.swp
 *.ipynb
+core/industry_ticker_map.py

--- a/README.md
+++ b/README.md
@@ -95,3 +95,11 @@ The application shows extra panels below the stock price chart:
 
 These indicators rely on the `ta` package, which is already listed in
 `requirements.txt`.
+
+## 銘柄リストの更新
+最新の銘柄リストを取得するには、以下のコマンドを実行してください。
+これにより、`core/industry_ticker_map.py` が自動生成されます。
+
+```bash
+python scripts/generate_ticker_map.py
+```

--- a/core/analysis.py
+++ b/core/analysis.py
@@ -24,18 +24,6 @@ TICKER_NAMES = {
     "9104.T": "商船三井",
 }
 
-INDUSTRY_TICKER_MAP = {
-    "自動車": {"7203": "トヨタ自動車", "7203.T": "トヨタ自動車"},
-    "電機": {"6758": "ソニーグループ", "6758.T": "ソニーグループ"},
-    "金融": {"8591": "オリックス", "8591.T": "オリックス"},
-    "海運": {
-        "9101": "日本郵船",
-        "9101.T": "日本郵船",
-        "9104": "商船三井",
-        "9104.T": "商船三井",
-    },
-}
-
 
 def _get_first_non_empty(tkr: yf.Ticker, attrs: list[str]) -> pd.DataFrame:
     """Return the first non-empty DataFrame among ticker attributes."""

--- a/core/views.py
+++ b/core/views.py
@@ -7,8 +7,8 @@ from .analysis import (
     analyze_stock_candlestick,
     predict_future_moves,
     _load_and_format_financials,
-    INDUSTRY_TICKER_MAP,
 )
+from .industry_ticker_map import INDUSTRY_TICKER_MAP
 from .gemini_analyzer import generate_analyst_report
 
 # Legacy attributes kept for test compatibility

--- a/scripts/generate_ticker_map.py
+++ b/scripts/generate_ticker_map.py
@@ -1,0 +1,44 @@
+import os
+from io import BytesIO
+import requests
+import pandas as pd
+
+URL = (
+    "https://www.jpx.co.jp/markets/statistics-equities/misc/"
+    "tvdivq0000001vg2-att/data_j.xls"
+)
+
+OUTPUT_PATH = os.path.join(
+    os.path.dirname(__file__), "..", "core", "industry_ticker_map.py"
+)
+
+
+def main():
+    """Download JPX tickers and generate industry map."""
+    response = requests.get(URL)
+    response.raise_for_status()
+    df = pd.read_excel(BytesIO(response.content), sheet_name="プライム")
+    df = df[["コード", "銘柄名", "33業種区分"]]
+    df["コード"] = df["コード"].astype(str).str.zfill(4)
+
+    industry_map: dict[str, dict[str, str]] = {}
+    for _, row in df.iterrows():
+        industry = row["33業種区分"]
+        code = row["コード"]
+        name = row["銘柄名"]
+        industry_map.setdefault(industry, {})[code] = name
+
+    out_path = os.path.abspath(OUTPUT_PATH)
+    with open(out_path, "w", encoding="utf-8") as f:
+        f.write("INDUSTRY_TICKER_MAP = {\n")
+        for ind, tickers in industry_map.items():
+            f.write(f"    {ind!r}: {{\n")
+            for code, name in tickers.items():
+                f.write(f"        {code!r}: {name!r},\n")
+            f.write("    },\n")
+        f.write("}\n")
+    print(f"Generated {out_path}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- プライム銘柄一覧を取得する `generate_ticker_map.py` を追加
- `core/industry_ticker_map.py` を自動生成対象として `.gitignore` に追加
- 手書きの `INDUSTRY_TICKER_MAP` を削除し、`core.views` で自動生成ファイルを参照
- README に銘柄リスト更新手順を追記

## Testing
- `flake8`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68583509500883299b08d1ce7b079467