### PR TITLE
Fix Procfile to generate ticker map before starting server

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: gunicorn myapp.wsgi --bind 0.0.0.0:$PORT
+web: python scripts/generate_ticker_map.py && gunicorn myapp.wsgi --bind 0.0.0.0:$PORT


### PR DESCRIPTION
## Summary
- modify Procfile to run `generate_ticker_map.py` before gunicorn starts

## Testing
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68591d5d1cc48329a955d6e8175a0a1b