### PR TITLE
Fix pandas version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ markdown2
 matplotlib
 mplfinance
 numpy
-pandas
+pandas==1.5.3
 psycopg2-binary
 pytest
 scikit-learn


### PR DESCRIPTION
## Summary
- pin pandas to 1.5.3 to match xlrd 1.2.0

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68592923bef883299f2fb8cc263b5edf