### PR TITLE
Fix pandas compatibility in analysis

### DIFF
--- a/core/analysis.py
+++ b/core/analysis.py
@@ -332,7 +332,7 @@ def analyze_stock_candlestick(ticker: str):
 
     tbl_cols = ["Close", "MACD", "RSI", "eps", "pe"]
     table_df = stock_data.tail(5)[tbl_cols].round(0)
-    table_df = table_df.map(lambda x: "-" if pd.isna(x) else int(x))
+    table_df = table_df.applymap(lambda x: "-" if pd.isna(x) else int(x))
     table_html = table_df.reset_index().rename(columns={"index": "date"}).to_html(
         classes="table table-striped", index=False
     )

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ lightgbm
 markdown2
 matplotlib
 mplfinance
-numpy
+numpy==1.23.5
 pandas==1.5.3
 psycopg2-binary
 pytest


### PR DESCRIPTION
## Summary
- use DataFrame.applymap instead of map so tests pass under pandas 1.5

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685932a4a75083299386101bf7056d56