### PR TITLE
Add setuptools for Python 3.12 compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-django-environ
 Django>=4.2
+django-environ
 flake8
 google-generativeai
 gunicorn
@@ -13,6 +13,7 @@ pandas==1.5.3
 psycopg2-binary
 pytest
 scikit-learn
+setuptools
 ta
 xlrd==1.2.0
 yfinance


### PR DESCRIPTION
## Summary
- fix Python 3.12 distutils issue by installing `setuptools` first
- keep requirements file alphabetized

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685958100ec08329926378b5d8a449a4