### PR TITLE
Fix Docker startup to generate tickers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,4 +23,4 @@ EXPOSE 8080
 
 # 起動コマンドを設定
 # まず銘柄リストを生成し、次にgunicornを起動
-CMD ["sh", "-c", "python scripts/generate_ticker_map.py && gunicorn myapp.wsgi --bind 0.0.0.0:8080"]
+CMD python scripts/generate_ticker_map.py && gunicorn myapp.wsgi


### PR DESCRIPTION
## Summary
- run ticker map generation then start gunicorn via CMD

## Testing
- `flake8`
- `pytest` *(fails: ModuleNotFoundError: No module named 'django')*
- `pip install -r requirements.txt` *(fails: No matching distribution found for pyxls)*

------
https://chatgpt.com/codex/tasks/task_e_68597989412083299b2a640c895eea9d