### PR TITLE
Fix Procfile binding to port

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: python scripts/generate_ticker_map.py && gunicorn myapp.wsgi
+web: python scripts/generate_ticker_map.py && gunicorn myapp.wsgi --bind 0.0.0.0:$PORT


### PR DESCRIPTION
## Summary
- update `Procfile` so gunicorn binds to `$PORT`

## Testing
- `flake8`
- `pytest` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_685987532ca08329b6dfc1cab3e4ee14