### PR TITLE
Switch to Railway config

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,0 @@
-web: python scripts/generate_ticker_map.py && gunicorn myapp.wsgi --bind 0.0.0.0:$PORT

--- a/railway.json
+++ b/railway.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://railway.app/railway.schema.json",
+  "build": {
+    "builder": "NIXPACKS"
+  },
+  "deploy": {
+    "startCommand": "python scripts/generate_ticker_map.py && gunicorn myapp.wsgi --bind 0.0.0.0:$PORT",
+    "restartPolicyType": "ON_FAILURE",
+    "restartPolicyMaxRetries": 10
+  }
+}


### PR DESCRIPTION
## Summary
- remove unused `Procfile`
- add `railway.json` to define start command

## Testing
- `flake8` *(fails: command not found)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68598983352083299ba1f238eccfadb2