### PR TITLE
Fix Procfile for Railway deployment

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: gunicorn myapp.wsgi --bind 0.0.0.0:$PORT
+web: gunicorn myapp.wsgi


### PR DESCRIPTION
## Summary
- simplify `Procfile` to use Railway's automatic port handling

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_685a6af667cc8329a62a04b54571dea1