### PR TITLE
Update NumPy for Python 3.12

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ Django>=4.2
 gunicorn
 psycopg2-binary
 django-environ
-numpy==1.23.5
+numpy>=1.24,<1.26
 pandas==1.3.5
 xlrd==1.2.0
 yfinance


### PR DESCRIPTION
## Summary
- upgrade numpy requirement to a Python 3.12 compatible range

## Testing
- `pip install -r requirements.txt` *(fails: building pandas wheels)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_685c9480f8b483298c6afb5af84d969b