### PR TITLE
Update dependencies and docs for Gemini

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ DATABASE_URL=your-database-url
 DEBUG=True
 ALLOWED_HOSTS=*
 JQUANTS_TOKEN=your-token  # optional
+GEMINI_API_KEY=あなたのAPIキー
 ```
 
 **Important:** Variable names must match exactly with no spaces.

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,8 +2,9 @@ Django>=4.2
 gunicorn
 psycopg2-binary
 django-environ
-numpy>=1.24,<1.26
-pandas==1.3.5
+numpy==1.23.5
+pandas==1.5.3
+google-generativeai
 xlrd==1.2.0
 yfinance
 mplfinance


### PR DESCRIPTION
## Summary
- freeze numpy and pandas at stable versions
- add `google-generativeai` dependency
- document new `GEMINI_API_KEY` environment variable

## Testing
- `railway up` *(fails: command not found)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685dc2bc64d48329a10fe8346e53c5bd