### PR TITLE
Add Railway CLI docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,3 +110,17 @@ These indicators rely on the `ta` package, which is already listed in
 ```bash
 python scripts/generate_ticker_map.py
 ```
+
+## Deploy to Railway
+
+1. Railway CLI をインストール（ローカル環境で一度だけ実行）:
+   npm:
+     npm install -g railway
+   Homebrew (macOS):
+     brew tap railway/homebrew && brew install railway
+
+2. CLI でログイン:
+   railway login
+
+3. デプロイ:
+   railway up


### PR DESCRIPTION
## Summary
- document install steps for the Railway CLI

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: Missing optional dependency 'Jinja2')*
- `flake8`


------
https://chatgpt.com/codex/tasks/task_e_685dc477db1483298e7e59a33383764b