### PR TITLE
Add Jinja2 dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,3 +110,17 @@ These indicators rely on the `ta` package, which is already listed in
 ```bash
 python scripts/generate_ticker_map.py
 ```
+
+## Deploy to Railway
+
+1. Railway CLI をインストール（ローカル環境で一度だけ実行）:
+   npm:
+     npm install -g railway
+   Homebrew (macOS):
+     brew tap railway/homebrew && brew install railway
+
+2. CLI でログイン:
+   railway login
+
+3. デプロイ:
+   railway up

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,9 @@ django-environ
 numpy==1.23.5
 pandas==1.5.3
 google-generativeai
+
+# テストで必要なテンプレートエンジン
+Jinja2>=3.0.0
 xlrd==1.2.0
 yfinance
 mplfinance


### PR DESCRIPTION
## Summary
- add Jinja2 to requirements for tests

## Testing
- `pip install -r requirements.txt`
- `pytest -q`
- `flake8`


------
https://chatgpt.com/codex/tasks/task_e_685dc477db1483298e7e59a33383764b