### PR TITLE
Add Railway deploy docs and update allowed hosts

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,14 +113,29 @@ python scripts/generate_ticker_map.py
 
 ## Deploy to Railway
 
-1. Railway CLI をインストール（ローカル環境で一度だけ実行）:
-   npm:
-     npm install -g railway
-   Homebrew (macOS):
-     brew tap railway/homebrew && brew install railway
+1. **Railway CLI をインストール**（ローカル環境で一度だけ）
+   ```bash
+   # npm
+   npm install -g railway
+   # macOS Homebrew
+   brew tap railway/homebrew && brew install railway
+   ```
 
-2. CLI でログイン:
+2. **ログイン＆プロジェクト設定**
+   ```bash
    railway login
+   railway link       # 既存プロジェクトを紐付け
+   # または
+   railway init       # 新規プロジェクト作成
+   ```
 
-3. デプロイ:
-   railway up
+3. **デプロイ**
+   ```bash
+   railway up --detach
+   ```
+
+4. **環境変数の登録**
+   ```bash
+   railway variables set GEMINI_API_KEY=<あなたのキー>
+   railway variables set JQUANTS_TOKEN=<あなたのトークン>
+   ```

--- a/myapp/settings.py
+++ b/myapp/settings.py
@@ -32,12 +32,12 @@ SECRET_KEY = env("SECRET_KEY")
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = env("DEBUG")
 
-# Allowed hosts configured via environment variable
-ALLOWED_HOSTS = env.list("ALLOWED_HOSTS", default=[])
-if DEBUG:
-    ALLOWED_HOSTS.extend(["localhost", "127.0.0.1"])
-if not ALLOWED_HOSTS:
-    ALLOWED_HOSTS = ["*"]
+# Allowed hosts configured for local and Railway deployments
+ALLOWED_HOSTS = [
+    "localhost",
+    "127.0.0.1",
+    ".railway.app",
+]
 
 
 # Application definition


### PR DESCRIPTION
## Summary
- add detailed Railway CLI usage steps in README
- update Django `ALLOWED_HOSTS` for Railway deployment

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685dcdb10ec88329835c8164e04ea546