### PR TITLE
Add whitenoise and break-system-packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,11 +17,11 @@ jobs:
 
       - name: Install build tools
         run: |
-          python -m pip install --upgrade pip
-          pip install setuptools wheel
+          python -m pip install --upgrade pip --break-system-packages
+          pip install --break-system-packages setuptools wheel
 
       - name: Install dependencies
-        run: pip install -r requirements.txt
+        run: pip install --break-system-packages -r requirements.txt
 
       - name: Run tests
         run: pytest -q

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ django-environ
 numpy==1.23.5
 pandas==1.5.3
 google-generativeai
+whitenoise
 
 # テストで必要なテンプレートエンジン
 Jinja2>=3.0.0


### PR DESCRIPTION
## Summary
- add whitenoise to dependencies
- use pip `--break-system-packages` option in CI to avoid system python issues

## Testing
- `pytest -q` *(fails: pyenv version `3.11.10` is not installed)*
- `flake8` *(not run due to previous failure)*


------
https://chatgpt.com/codex/tasks/task_e_685df1642fc08329923820639f634941