### PR TITLE
Add STATIC_ROOT for collectstatic

### DIFF
--- a/myapp/settings.py
+++ b/myapp/settings.py
@@ -15,6 +15,10 @@ import environ
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
+# -------------------------------------------------------------------
+# collectstatic 用の出力先を指定
+STATIC_ROOT = BASE_DIR / "staticfiles"
+# -------------------------------------------------------------------
 
 # Environment setup
 env = environ.Env(


### PR DESCRIPTION
## Summary
- fix missing `STATIC_ROOT` error by specifying `STATIC_ROOT = BASE_DIR / "staticfiles"`

## Testing
- `pip install --break-system-packages -r requirements.txt` *(fails: subprocess-exited-with-error)*
- `pytest -q` *(fails: pyenv version `3.11.10` is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685e0d764bd88329b6321b54d1ea0991