### PR TITLE
Add health check endpoint & switch gemini logging

### DIFF
--- a/core/gemini_analyzer.py
+++ b/core/gemini_analyzer.py
@@ -1,12 +1,13 @@
 import os
 import pandas as pd
 import google.generativeai as genai
+import logging
 
 api_key = os.environ.get("GEMINI_API_KEY")
 if api_key:
     genai.configure(api_key=api_key)
 else:
-    print("Warning: GEMINI_API_KEY is not set.")
+    logging.warning("GEMINI_API_KEY is not set, Gemini features will be disabled.")
 
 
 def generate_analyst_report(

--- a/core/tests/test_analysis.py
+++ b/core/tests/test_analysis.py
@@ -93,7 +93,7 @@ class AnalysisTests(SimpleTestCase):
         self, mock_analyze, mock_predict, mock_fin
     ):
         mock_analyze.return_value = ("chart", "<table></table>", None)
-        response = self.client.get("/?ticker1=7203", HTTP_HOST="localhost")
+        response = self.client.get("/analysis/?ticker1=7203", HTTP_HOST="localhost")
         self.assertEqual(response.status_code, 200)
         mock_analyze.assert_called_once_with("7203")
         self.assertIn("chart", response.content.decode())
@@ -107,7 +107,7 @@ class AnalysisTests(SimpleTestCase):
     ):
         mock_analyze.return_value = ("chart", "<table></table>", None)
         response = self.client.get(
-            "/?ticker1=7203&ticker2=6758", HTTP_HOST="localhost"
+            "/analysis/?ticker1=7203&ticker2=6758", HTTP_HOST="localhost"
         )
         self.assertEqual(response.status_code, 200)
         self.assertEqual(mock_analyze.call_count, 2)
@@ -138,7 +138,7 @@ class AnalysisTests(SimpleTestCase):
             "<table><tr><th>Total Revenue</th><td>1</td></tr></table>"
         )
         response = self.client.get(
-            "/?ticker1=7203", HTTP_HOST="localhost"
+            "/analysis/?ticker1=7203", HTTP_HOST="localhost"
         )
         self.assertEqual(response.status_code, 200)
         content = response.content.decode()
@@ -155,7 +155,7 @@ class AnalysisTests(SimpleTestCase):
             "<h3>Quarterly Financials</h3><table></table>",
             "<h3>Annual Financials</h3><table></table>",
         ]
-        response = self.client.get("/?ticker1=7203", HTTP_HOST="localhost")
+        response = self.client.get("/analysis/?ticker1=7203", HTTP_HOST="localhost")
         self.assertEqual(response.status_code, 200)
         content = response.content.decode()
         self.assertIn("Quarterly Financials", content)

--- a/core/tests/test_views.py
+++ b/core/tests/test_views.py
@@ -1,0 +1,19 @@
+import os
+import django
+from django.test import Client, SimpleTestCase
+from django.urls import reverse
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "myapp.settings")
+os.environ.setdefault("SECRET_KEY", "dummy")
+os.environ.setdefault("DEBUG", "True")
+
+django.setup()
+
+
+class HealthCheckTests(SimpleTestCase):
+    def test_health_check(self):
+        client = Client()
+        url = reverse("health_check")
+        response = client.get(url, HTTP_HOST="localhost")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.content, b"OK")

--- a/core/urls.py
+++ b/core/urls.py
@@ -2,5 +2,5 @@ from django.urls import path
 from .views import main_analysis_view
 
 urlpatterns = [
-    path('', main_analysis_view, name='analysis'),
+    path('analysis/', main_analysis_view, name='analysis'),
 ]

--- a/core/views.py
+++ b/core/views.py
@@ -1,6 +1,8 @@
 from django.shortcuts import render
 import pandas as pd
 import markdown2
+import logging
+from django.http import HttpResponse
 
 from .analysis import (
     get_company_name,
@@ -10,6 +12,13 @@ from .analysis import (
 )
 from .industry_ticker_map import INDUSTRY_TICKER_MAP
 from .gemini_analyzer import generate_analyst_report
+
+
+def health_check(request):
+    """軽量なヘルスチェック用エンドポイント"""
+    logging.getLogger(__name__).debug("health check accessed")
+    return HttpResponse("OK")
+
 
 # Legacy attributes kept for test compatibility
 _load_financial_metrics = None

--- a/myapp/urls.py
+++ b/myapp/urls.py
@@ -17,8 +17,12 @@ Including another URLconf
 
 from django.contrib import admin
 from django.urls import path, include
+from core.views import health_check
 
 urlpatterns = [
+    # ヘルスチェック（RailwayのhealthcheckPath用）
+    path("", health_check, name="health_check"),
+    # 既存ルーティング
     path("admin/", admin.site.urls),
     path("", include("core.urls")),
 ]


### PR DESCRIPTION
## Summary
- add `health_check` view and URL pattern
- expose analysis view at `/analysis/`
- add health check tests and adjust existing tests
- use `logging.warning` instead of `print` in gemini analyzer

## Testing
- `pytest -q`
- `flake8`


------
https://chatgpt.com/codex/tasks/task_e_685e65a215b48329a05a5bf188b5601f