### PR TITLE
Fix Railway build env and health check URL

### DIFF
--- a/core/tests/test_analysis.py
+++ b/core/tests/test_analysis.py
@@ -93,7 +93,7 @@ class AnalysisTests(SimpleTestCase):
         self, mock_analyze, mock_predict, mock_fin
     ):
         mock_analyze.return_value = ("chart", "<table></table>", None)
-        response = self.client.get("/analysis/?ticker1=7203", HTTP_HOST="localhost")
+        response = self.client.get("/?ticker1=7203", HTTP_HOST="localhost")
         self.assertEqual(response.status_code, 200)
         mock_analyze.assert_called_once_with("7203")
         self.assertIn("chart", response.content.decode())
@@ -107,7 +107,7 @@ class AnalysisTests(SimpleTestCase):
     ):
         mock_analyze.return_value = ("chart", "<table></table>", None)
         response = self.client.get(
-            "/analysis/?ticker1=7203&ticker2=6758", HTTP_HOST="localhost"
+            "/?ticker1=7203&ticker2=6758", HTTP_HOST="localhost"
         )
         self.assertEqual(response.status_code, 200)
         self.assertEqual(mock_analyze.call_count, 2)
@@ -138,7 +138,7 @@ class AnalysisTests(SimpleTestCase):
             "<table><tr><th>Total Revenue</th><td>1</td></tr></table>"
         )
         response = self.client.get(
-            "/analysis/?ticker1=7203", HTTP_HOST="localhost"
+            "/?ticker1=7203", HTTP_HOST="localhost"
         )
         self.assertEqual(response.status_code, 200)
         content = response.content.decode()
@@ -155,7 +155,7 @@ class AnalysisTests(SimpleTestCase):
             "<h3>Quarterly Financials</h3><table></table>",
             "<h3>Annual Financials</h3><table></table>",
         ]
-        response = self.client.get("/analysis/?ticker1=7203", HTTP_HOST="localhost")
+        response = self.client.get("/?ticker1=7203", HTTP_HOST="localhost")
         self.assertEqual(response.status_code, 200)
         content = response.content.decode()
         self.assertIn("Quarterly Financials", content)

--- a/core/urls.py
+++ b/core/urls.py
@@ -1,6 +1,6 @@
 from django.urls import path
-from .views import main_analysis_view
+from . import views
 
 urlpatterns = [
-    path('analysis/', main_analysis_view, name='analysis'),
+    path('', views.main_analysis_view, name='main_analysis'),
 ]

--- a/myapp/urls.py
+++ b/myapp/urls.py
@@ -21,7 +21,7 @@ from core.views import health_check
 
 urlpatterns = [
     # ヘルスチェック（RailwayのhealthcheckPath用）
-    path("", health_check, name="health_check"),
+    path("health/", health_check, name="health_check"),
     # 既存ルーティング
     path("admin/", admin.site.urls),
     path("", include("core.urls")),

--- a/railway.json
+++ b/railway.json
@@ -1,8 +1,12 @@
 {
-  "build": { "dockerfilePath": "Dockerfile" },
+  "$schema": "https://railway.app/railway.schema.json",
+  "build": {
+    "builder": "NIXPACKS",
+    "buildCommand": "python3 -m venv .venv && . .venv/bin/activate && pip install --upgrade pip && pip install -r requirements.txt && python manage.py collectstatic --noinput"
+  },
   "deploy": {
-    "startCommand": "gunicorn myapp.wsgi --bind 0.0.0.0:8000 --log-file -",
-    "healthcheckPath": "/",
-    "port": 8000
+    "startCommand": ". .venv/bin/activate && python manage.py migrate && gunicorn myapp.wsgi --log-file -",
+    "healthcheckPath": "/health/",
+    "healthcheckTimeout": 120
   }
 }


### PR DESCRIPTION
## Summary
- build Python app using a venv in `railway.json`
- move health check to `/health/`
- simplify core URL to root path
- adjust tests for new path

## Testing
- `pytest -q` *(fails: No module named pytest)*

------
https://chatgpt.com/codex/tasks/task_e_685e7076dc48832998d69082a19b163f