### PR TITLE
Add Gemini error handling

### DIFF
--- a/core/gemini_analyzer.py
+++ b/core/gemini_analyzer.py
@@ -65,25 +65,31 @@ def generate_analyst_report(
 - **ストップロス:** （考察結果からストップロスに関する記述を抽出）
 ```
 """
-    try:
-        model = genai.GenerativeModel("gemini-1.5-flash")
-        generation_config = genai.types.GenerationConfig(temperature=0.2)
+    model = genai.GenerativeModel("gemini-1.5-flash")
+    generation_config = genai.types.GenerationConfig(temperature=0.2)
 
-        # ステップ1: 思考
+    # ステップ1: 思考
+    try:
         reasoning_resp = model.generate_content(
             reasoning_prompt, generation_config=generation_config
         )
+    except Exception as e:
+        logging.error(f"Gemini call failed: {e}", exc_info=True)
+        return "（AIレポート生成エラー）"
 
-        # ステップ2: 校正
-        final_prompt = final_prompt_template.format(
-            ticker_name=ticker_name,
-            ticker_code=ticker_code,
-            reasoning_text=reasoning_resp.text,
-        )
+    # ステップ2: 校正
+    final_prompt = final_prompt_template.format(
+        ticker_name=ticker_name,
+        ticker_code=ticker_code,
+        reasoning_text=reasoning_resp.text,
+    )
 
+    try:
         final_resp = model.generate_content(
             final_prompt, generation_config=generation_config
         )
-        return final_resp.text
     except Exception as e:
-        return f"Error generating report from Gemini: {e}"
+        logging.error(f"Gemini call failed: {e}", exc_info=True)
+        return "（AIレポート生成エラー）"
+
+    return final_resp.text


### PR DESCRIPTION
## Summary
- guard Gemini API calls in `generate_analyst_report` so workers don't crash

## Testing
- `flake8 core/gemini_analyzer.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686014e074e08329af1bdefa34a9d5e7