### PR TITLE
Fix Excel import and admin; unify prediction headers

### DIFF
--- a/core/admin.py
+++ b/core/admin.py
@@ -1,1 +1,14 @@
-# Register your models here.
+from django.contrib import admin
+from .models import Industry, Ticker
+
+
+@admin.register(Industry)
+class IndustryAdmin(admin.ModelAdmin):
+    list_display = ("name",)
+
+
+@admin.register(Ticker)
+class TickerAdmin(admin.ModelAdmin):
+    list_display = ("code", "name", "industry")
+    list_filter = ("industry",)
+    search_fields = ("code", "name")

--- a/core/analysis.py
+++ b/core/analysis.py
@@ -25,6 +25,15 @@ TICKER_NAMES = {
 }
 
 
+# Shared header names for prediction tables
+PREDICTION_COLUMNS = [
+    "予測日数",
+    "予想方向",
+    "上昇確率",
+    "期待リターン",
+]
+
+
 def _get_first_non_empty(tkr: yf.Ticker, attrs: list[str]) -> pd.DataFrame:
     """Return the first non-empty DataFrame among ticker attributes."""
     for attr in attrs:
@@ -499,10 +508,10 @@ def predict_future_moves(ticker: str, horizons=None):
 
         results.append(
             {
-                "予測日数": h,
-                "Prediction": prediction,
-                "上昇確率": round(prob_up * 100),
-                "期待リターン": expected_return,
+                PREDICTION_COLUMNS[0]: h,
+                PREDICTION_COLUMNS[1]: prediction,
+                PREDICTION_COLUMNS[2]: round(prob_up * 100),
+                PREDICTION_COLUMNS[3]: expected_return,
             }
         )
 
@@ -510,7 +519,7 @@ def predict_future_moves(ticker: str, horizons=None):
         return (None, None)
 
     table = pd.DataFrame(results)
-    prob_col = "上昇確率"
+    prob_col = PREDICTION_COLUMNS[2]
 
     def color_scale(val: float) -> str:
         if val == 50:
@@ -523,7 +532,7 @@ def predict_future_moves(ticker: str, horizons=None):
 
     styled_table = (
         table.style.applymap(color_scale, subset=[prob_col])
-        .format({prob_col: "{:.0f}%", "期待リターン": lambda x: f"{x:+.2f}%"})
+        .format({prob_col: "{:.0f}%", PREDICTION_COLUMNS[3]: lambda x: f"{x:+.2f}%"})
         .hide(axis="index")
         .set_table_attributes('class="table table-striped"')
     )

--- a/core/management/commands/load_tickers.py
+++ b/core/management/commands/load_tickers.py
@@ -12,8 +12,10 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         path = Path(settings.BASE_DIR) / "data_j.xls"
-        df = pd.read_excel(path, header=None)
+        df = pd.read_excel(path, header=0, engine="xlrd")
         for _, row in df.iterrows():
+            if pd.isna(row[0]) or pd.isna(row[1]) or pd.isna(row[2]):
+                continue
             industry_name = row[0]
             code = str(row[1]).zfill(4)
             name = row[2]

--- a/core/tests/test_analysis.py
+++ b/core/tests/test_analysis.py
@@ -16,12 +16,18 @@ from core.analysis import analyze_stock_candlestick, predict_future_moves
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'myapp.settings')
 os.environ.setdefault('SECRET_KEY', 'a-dummy-secret-key-for-testing')
 os.environ.setdefault('DEBUG', 'True')
+os.environ['ALLOWED_HOSTS'] = 'localhost,127.0.0.1'
 django.setup()
 
 # ダミーの industry_ticker_map モジュール
 sys.modules.setdefault(
     'core.industry_ticker_map',
     types.SimpleNamespace(INDUSTRY_TICKER_MAP={}),
+)
+# ダミーの gemini_analyzer モジュール
+sys.modules.setdefault(
+    'core.gemini_analyzer',
+    types.SimpleNamespace(generate_analyst_report=lambda *a, **k: ""),
 )
 
 # --- テスト用サンプルデータ準備 ---
@@ -50,7 +56,7 @@ class AnalysisTests(SimpleTestCase):
         self.assertIsNone(none_val)
         if html:
             self.assertIn("<table", html)
-            self.assertIn("Prediction", html)
+            self.assertIn("予想方向", html)
             self.assertIn("期待リターン", html)
 
     @patch("core.views._load_and_format_financials", return_value="")


### PR DESCRIPTION
## Summary
- read tickers Excel file with header row and skip NaN lines
- register `Industry` and `Ticker` models in the admin
- use shared Japanese headers for prediction tables
- adjust tests for new headers and configure env vars

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686029db7038832981b49d05643338a5