### PR TITLE
Add Railway post deploy workflow

### DIFF
--- a/.github/workflows/railway_post_deploy.yml
+++ b/.github/workflows/railway_post_deploy.yml
@@ -1,0 +1,20 @@
+name: Railway Post Deploy
+
+on:
+  deployment_status:
+
+jobs:
+  post-deploy-commands:
+    if: ${{ github.event.deployment_status.state == 'success' && github.event.deployment.environment == 'production' && contains(github.event.deployment_status.environment_url, 'railway.app') }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: railwayapp/cli@v2
+      - name: Run Migrate
+        run: railway run python manage.py migrate
+        env:
+          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
+      - name: Run Script to Populate Data
+        run: railway run python scripts/update_tickers_from_csv.py
+        env:
+          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}


### PR DESCRIPTION
## Summary
- trigger `deployment_status` event for Railway post deployment tasks
- run migrations and data scripts if the deployment succeeded on production

## Testing
- `pip install -r requirements.txt` *(fails: subprocess-exited-with-error)*

------
https://chatgpt.com/codex/tasks/task_e_6860c89c8a548329b87426aa73cb52f2