### PR TITLE
Fix CSV path setup

### DIFF
--- a/scripts/update_tickers_from_csv.py
+++ b/scripts/update_tickers_from_csv.py
@@ -1,4 +1,6 @@
 import os
+from pathlib import Path
+
 import django
 import pandas as pd
 from django.db import transaction
@@ -8,7 +10,9 @@ django.setup()
 
 from core.models import Industry, Ticker  # noqa: E402
 
-CSV_PATH = os.path.join(os.path.dirname(__file__), "..", "data_j.csv")
+# スクリプトファイルの場所を基点にプロジェクトルートの絶対パスを取得
+BASE_DIR = Path(__file__).resolve().parent.parent
+CSV_PATH = BASE_DIR / "data_j.csv"
 
 KEEP_MARKETS = {
     "プライム（内国株式）",


### PR DESCRIPTION
## Summary
- clean up import style
- confirm CSV_PATH uses absolute project root via pathlib

## Testing
- `python3 -m py_compile scripts/update_tickers_from_csv.py`
- `flake8 scripts/update_tickers_from_csv.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6860d14c97a483299d1f594ba355bc09