### PR TITLE
Modify Railway post-deploy workflow trigger

### DIFF
--- a/.github/workflows/railway_post_deploy.yml
+++ b/.github/workflows/railway_post_deploy.yml
@@ -1,11 +1,14 @@
 name: Railway Post Deploy
 
 on:
-  deployment_status:
+  workflow_run:
+    workflows: ["Deploy to Railway"]
+    types:
+      - completed
 
 jobs:
   post-deploy-commands:
-    if: ${{ github.event.deployment_status.state == 'success' && github.event.deployment.environment == 'production' && contains(github.event.deployment_status.environment_url, 'railway.app') }}
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- trigger `railway_post_deploy.yml` on a successful `Deploy to Railway` workflow
- ensure job only runs once after the workflow succeeds

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*


------
https://chatgpt.com/codex/tasks/task_e_6860d6c36ad08329b753a7ed291dab89