### PR TITLE
Add migrations step to Django CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,11 @@ jobs:
           pip install --upgrade pip setuptools wheel
           pip install -r requirements.txt -r requirements-dev.txt
           # これで pandas と openpyxl も入り、Excelスクリプトが動くようになる
+      - name: Run Migrations
+        shell: bash
+        run: |
+          source .venv/bin/activate
+          python manage.py migrate
       - name: Run Tests
         shell: bash
         env:


### PR DESCRIPTION
## Summary
- add a Run Migrations step before tests in CI

## Testing
- `pytest -q` *(fails: pyenv: version `3.11.10` is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6860db6761308329ad1ccb363ecbad5d