### PR TITLE
Fix report header and ticker select

### DIFF
--- a/core/gemini_analyzer.py
+++ b/core/gemini_analyzer.py
@@ -2,6 +2,7 @@ import os
 import pandas as pd
 import google.generativeai as genai
 import logging
+from datetime import date
 
 api_key = os.environ.get("GEMINI_API_KEY")
 if api_key:
@@ -29,12 +30,12 @@ def generate_analyst_report(
     latest_data_text = (
         pd.DataFrame(latest_data_dict).to_string(index=False)
         if latest_data_dict
-        else "（テクニカル指標データなし）"
+        else ""
     )
     predictions_text = (
         pd.DataFrame(predictions_dict).to_string(index=False)
         if predictions_dict
-        else "（モデル予測データなし）"
+        else ""
     )
 
     reasoning_prompt = f"""
@@ -54,8 +55,8 @@ def generate_analyst_report(
 
 {reasoning_text}
 
-```markdown
-### 投資戦略サマリー：{ticker_name}
+### 投資戦略サマリー：{ticker_name} ({ticker_code})
+作成日：{date.today().strftime("%Y年%m月%d日")}
 
 | 評価軸 | 分析結果と判断 |
 |:---|:---|
@@ -69,7 +70,6 @@ def generate_analyst_report(
 - **エントリーポイント:** （考察結果からエントリーポイントに関する記述を抽出）
 - **ターゲットプライス:** （考察結果からターゲットプライスに関する記述を抽出）
 - **ストップロス:** （考察結果からストップロスに関する記述を抽出）
-```
 """
     if _model is None:
         return "Gemini API key is not configured."

--- a/core/static/js/ticker-selector.js
+++ b/core/static/js/ticker-selector.js
@@ -1,4 +1,5 @@
-fetch('/api/industries/')
+const industriesUrl = "{% url 'api-industries' %}";
+fetch(industriesUrl)
   .then(r => r.json())
   .then(data => {
     const ilist = document.getElementById('industry-list');
@@ -7,7 +8,8 @@ fetch('/api/industries/')
       li.textContent = ind.name;
       li.style.cursor = 'pointer';
       li.addEventListener('click', () => {
-        fetch(`/api/industries/${ind.id}/tickers/`)
+        const tickersUrl = (id) => "{% url 'api-industry-tickers' 0 %}".replace("0", id);
+        fetch(tickersUrl(ind.id))
           .then(r => r.json())
           .then(tickers => {
             const tlist = document.getElementById('ticker-list');

--- a/core/templates/core/main_analysis.html
+++ b/core/templates/core/main_analysis.html
@@ -1,5 +1,6 @@
 {% extends 'base.html' %}
-{% load json_extras static %}
+{% load static %}
+{% load json_extras %}
 {% block content %}
 <h1>Candlestick Analysis</h1>
   <form method="get" class="row g-2 mb-3">
@@ -36,7 +37,7 @@
       <div class="alert alert-warning">{{ data1.warning }}</div>
     {% endif %}
       {% if data1.chart_data %}
-        <h2>{{ data1.company_name|default:ticker1 }}</h2>
+        {% include "partials/report_header.html" with company_name=data1.company_name|default:ticker1 ticker=ticker1 today=today %}
         <img src="data:image/png;base64,{{ data1.chart_data }}" alt="Chart" class="img-fluid w-100">
       {% endif %}
     {% if data1.latest_data_table %}
@@ -49,9 +50,9 @@
     {% if data1.annual_table %}
       {{ data1.annual_table|safe }}
     {% endif %}
-      {% if data1.prediction_table %}
+      {% if data1.predictions %}
         <h3>Predictions</h3>
-        {{ data1.prediction_table|safe }}
+        {% include "partials/predictions_table.html" with predictions=data1.predictions %}
         {{ data1.gemini_report_html|safe }}
       {% endif %}
   </div>
@@ -60,7 +61,7 @@
       <div class="alert alert-warning">{{ data2.warning }}</div>
     {% endif %}
       {% if data2.chart_data %}
-        <h2>{{ data2.company_name|default:ticker2 }}</h2>
+        {% include "partials/report_header.html" with company_name=data2.company_name|default:ticker2 ticker=ticker2 today=today %}
         <img src="data:image/png;base64,{{ data2.chart_data }}" alt="Chart" class="img-fluid w-100">
       {% endif %}
     {% if data2.latest_data_table %}
@@ -73,58 +74,12 @@
     {% if data2.annual_table %}
       {{ data2.annual_table|safe }}
     {% endif %}
-      {% if data2.prediction_table %}
+      {% if data2.predictions %}
         <h3>Predictions</h3>
-        {{ data2.prediction_table|safe }}
+        {% include "partials/predictions_table.html" with predictions=data2.predictions %}
         {{ data2.gemini_report_html|safe }}
       {% endif %}
   </div>
 </div>
-  <script>
-  const industryMap = {{ industry_map | tojson | safe }};
-  const tickerModal = document.getElementById('tickerModal');
-  let activeInput = null;
-
-  // どの「銘柄検索」ボタンが押されたかを記録する
-  document.querySelectorAll('.ticker-btn').forEach(btn => {
-    btn.addEventListener('click', () => {
-      activeInput = document.querySelector(btn.dataset.input);
-    });
-  });
-
-  // モーダルが表示される直前のイベントを捕捉
-  tickerModal.addEventListener('show.bs.modal', () => {
-    const body = tickerModal.querySelector('.modal-body');
-    // モーダルの中身を一度空にする
-    body.innerHTML = '';
-
-    // industryMapのデータを使って、業種と銘柄のボタンを動的に生成する
-    for (const [industry, tickers] of Object.entries(industryMap)) {
-      const industryBlock = document.createElement('div');
-      industryBlock.className = 'mb-3';
-
-      const industryHeading = document.createElement('h6');
-      industryHeading.textContent = industry;
-      industryBlock.appendChild(industryHeading);
-
-      tickers.forEach(ticker => {
-        const button = document.createElement('button');
-        button.type = 'button';
-        button.className = 'btn btn-sm btn-outline-primary m-1';
-        button.textContent = `${ticker.code} ${ticker.name}`;
-
-        // ボタンがクリックされた時の処理
-        button.addEventListener('click', () => {
-          if (activeInput) {
-            activeInput.value = ticker.code; // 銘柄コードを入力欄に設定
-          }
-          bootstrap.Modal.getInstance(tickerModal).hide(); // モーダルを閉じる
-        });
-        industryBlock.appendChild(button);
-      });
-
-      body.appendChild(industryBlock);
-    }
-  });
-  </script>
+  <script src="{% static 'js/ticker-selector.js' %}"></script>
 {% endblock %}

--- a/core/templates/partials/predictions_table.html
+++ b/core/templates/partials/predictions_table.html
@@ -1,0 +1,17 @@
+<table class="table table-striped">
+  <thead>
+    <tr>
+      <th>予測日数</th><th>予測方向</th><th>上昇確率</th><th>期待リターン</th>
+    </tr>
+  </thead>
+  <tbody>
+  {% for row in predictions %}
+    <tr>
+      <td>{{ row.予測日数 }}</td>
+      <td>{{ row.予想方向 }}</td>
+      <td>{{ row.上昇確率 }}%</td>
+      <td>{{ row.期待リターン }}%</td>
+    </tr>
+  {% endfor %}
+  </tbody>
+</table>

--- a/core/templates/partials/report_header.html
+++ b/core/templates/partials/report_header.html
@@ -1,0 +1,2 @@
+<h2>投資戦略サマリー：{{ company_name }} ({{ ticker }})</h2>
+<p>作成日：{{ today }}</p>

--- a/core/urls.py
+++ b/core/urls.py
@@ -4,6 +4,6 @@ from . import views
 
 urlpatterns = [
     path('', views.main_analysis_view, name='main_analysis'),
-    path('api/industries/', views.IndustryListAPIView.as_view()),
-    path('api/industries/<int:pk>/tickers/', views.IndustryTickerAPIView.as_view()),
+    path('api/industries/', views.IndustryListAPIView.as_view(), name='api-industries'),
+    path('api/industries/<int:pk>/tickers/', views.IndustryTickerAPIView.as_view(), name='api-industry-tickers'),
 ]

--- a/core/views.py
+++ b/core/views.py
@@ -3,6 +3,7 @@ import pandas as pd
 import markdown2
 import logging
 from django.http import HttpResponse
+from datetime import date
 from rest_framework.views import APIView
 from rest_framework.response import Response
 
@@ -69,6 +70,7 @@ def fetch_data(ticker):
         "chart_data": chart_data,
         "latest_data_table": latest_table_html,
         "prediction_table": prediction_table_html,
+        "predictions": prediction_dict,
         "quarterly_table": quarterly_table,
         "annual_table": annual_table,
         "warning": warning,
@@ -89,6 +91,7 @@ def main_analysis_view(request):
     for industry in industries:
         tickers = industry.ticker_set.order_by("code").values("code", "name")
         industry_map_data[industry.name] = list(tickers)
+    today = date.today()
 
     context = {
         "ticker1": ticker1,
@@ -96,6 +99,7 @@ def main_analysis_view(request):
         "data1": data1,
         "data2": data2,
         "industry_map": industry_map_data,
+        "today": today,
     }
     return render(request, "core/main_analysis.html", context)
 

--- a/myapp/urls.py
+++ b/myapp/urls.py
@@ -1,11 +1,10 @@
 # myapp/urls.py
 from django.contrib import admin
-from django.urls import path, include
+from django.urls import include, path
 from core.views import health_check
 
 urlpatterns = [
     path("health/", health_check, name="health_check"),
     path("admin/", admin.site.urls),
-    path("core/", include("core.urls")),
     path("", include("core.urls")),
 ]


### PR DESCRIPTION
## Summary
- include current date in Gemini report output and create reusable header
- share prediction table layout via template partial
- remove insufficient data disclaimers
- make ticker selector fetch from API and wire up URLs

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6867f5c1834083299027c7ea0ce2087a